### PR TITLE
[Feat] 미리보기 저장을 통한 공지사항 성능 개선 및 인덱스 지정 #72

### DIFF
--- a/docs/add-indexes.sql
+++ b/docs/add-indexes.sql
@@ -1,0 +1,64 @@
+-- =============================================
+-- AjouEvent V2 — 인덱스 추가 (운영 DB ALTER)
+-- schema.sql은 CREATE TABLE IF NOT EXISTS 기반이므로
+-- 기존 테이블에는 아래 ALTER로 직접 적용
+-- =============================================
+
+-- topics
+ALTER TABLE topics
+    ADD INDEX idx_topics_department   (department),
+    ADD INDEX idx_topics_korean_topic (korean_topic);
+
+-- topic_members
+ALTER TABLE topic_members
+    ADD UNIQUE KEY uq_topic_members                    (member_id, topic_id),
+    ADD INDEX      idx_topic_members_member_isread      (member_id, is_read),
+    ADD INDEX      idx_topic_members_topic_notification (topic_id, receive_notification);
+
+-- topic_tokens
+ALTER TABLE topic_tokens
+    ADD INDEX idx_topic_tokens_topic_token (topic_id, token_value),
+    ADD INDEX idx_topic_tokens_token_value (token_value);
+
+-- keywords
+ALTER TABLE keywords
+    ADD UNIQUE KEY uq_keywords_encoded_keyword (encoded_keyword),
+    ADD INDEX      idx_keywords_search_keyword (search_keyword),
+    ADD INDEX      idx_keywords_topic_id       (topic_id);
+
+-- keyword_members
+ALTER TABLE keyword_members
+    ADD UNIQUE KEY uq_keyword_members               (member_id, keyword_id),
+    ADD INDEX      idx_keyword_members_member_isread (member_id, is_read),
+    ADD INDEX      idx_keyword_members_keyword_id    (keyword_id);
+
+-- keyword_tokens
+ALTER TABLE keyword_tokens
+    ADD INDEX idx_keyword_tokens_keyword_token (keyword_id, token_value),
+    ADD INDEX idx_keyword_tokens_token_value   (token_value);
+
+-- club_events
+ALTER TABLE club_events
+    ADD INDEX idx_club_events_type_createdat      (type, created_at),
+    ADD INDEX idx_club_events_createdat_viewcount  (created_at, view_count);
+
+-- event_likes
+ALTER TABLE event_likes
+    ADD UNIQUE KEY uq_event_likes (member_id, club_event_id);
+
+-- push_clusters
+ALTER TABLE push_clusters
+    ADD INDEX idx_push_clusters_job_status (job_status);
+
+-- push_cluster_tokens
+ALTER TABLE push_cluster_tokens
+    ADD INDEX idx_pct_push_cluster_id  (push_cluster_id),
+    ADD INDEX idx_pct_status_request   (job_status, request_time),
+    ADD INDEX idx_pct_status_processed (job_status, processed_time),
+    ADD INDEX idx_pct_status_retry     (job_status, retry_after, retry_count);
+
+-- push_notifications
+ALTER TABLE push_notifications
+    ADD INDEX idx_pn_member_type_notified (member_id, notification_type, notified_at),
+    ADD INDEX idx_pn_member_isread        (member_id, is_read),
+    ADD INDEX idx_pn_push_cluster_id      (push_cluster_id);

--- a/docs/test-text-varchar.sql
+++ b/docs/test-text-varchar.sql
@@ -1,0 +1,66 @@
+-- =============================================
+-- AjouEvent V2 — 성능 최적화 및 부하 테스트 스크립트
+-- schema.sql은 CREATE TABLE IF NOT EXISTS 기반이므로
+-- 기존 테이블에는 아래 ALTER 및 UPDATE 구문으로 직접 적용합니다.
+-- =============================================
+
+-- ---------------------------------------------
+-- 1. 스키마 마이그레이션 (Schema Migration)
+-- ---------------------------------------------
+-- 목적: 읽기(Read) 성능 향상 및 Sort Buffer 오버헤드 감소를 위한 페이로드 분리
+ALTER TABLE club_events
+    ADD COLUMN content_preview VARCHAR(200) AFTER content;
+
+-- 기존 데이터 백필 (Backfill)
+UPDATE club_events
+SET content_preview = LEFT(content, 200)
+WHERE content_preview IS NULL;
+
+
+-- ---------------------------------------------
+-- 2. 부하 테스트용 더미 데이터 적재 (Dummy Data Seeding)
+-- ---------------------------------------------
+-- 목적: Full Table Scan 및 Using filesort 병목을 검증하기 위한 5만 건 데이터 Bulk Insert
+-- 주의: CTE 무한 루프 방지용 세션 변수(cte_max_recursion_depth) 선행 조정 필수
+SET SESSION cte_max_recursion_depth = 100000;
+
+INSERT INTO club_events (title, content, content_preview, writer, created_at, type, subject, url, likes_count, view_count)
+WITH RECURSIVE seq(n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM seq WHERE n < 50000
+)
+SELECT
+    CONCAT('공지사항 ', n),
+    REPEAT('본문 내용입니다. ', 200),
+    LEFT(REPEAT('본문 내용입니다. ', 200), 200),
+    '소프트웨어학과',
+    NOW() - INTERVAL n SECOND, -- 인덱스 정렬 테스트를 위한 타임스탬프 분산
+    'AJOUNORMAL',
+    '소프트웨어학과',
+    CONCAT('https://example.com/', n),
+    0, 0
+FROM seq;
+
+
+-- ---------------------------------------------
+-- 3. 실행 계획 및 성능 비교 분석 (EXPLAIN ANALYZE)
+-- ---------------------------------------------
+
+-- [Test A: 개선 전 모델] Heavy Payload 조회
+-- 목적: content(TEXT) 포함 시 메모리 적재량 증가에 따른 Sort 연산 병목 및 디스크 I/O 소요 시간 측정
+EXPLAIN ANALYZE
+SELECT event_id, title, content, writer, created_at, likes_count, view_count, type, subject, url
+FROM club_events
+WHERE type IN ('AJOUNORMAL')
+ORDER BY created_at DESC
+    LIMIT 20;
+
+-- [Test B: 개선 후 모델] Light Payload 조회
+-- 목적: content_preview(VARCHAR) 대체 시 레코드 크기 축소로 인한 메모리 내 정렬(In-memory Sort) 효율 및 속도 단축 비율 검증
+EXPLAIN ANALYZE
+SELECT event_id, title, content_preview, writer, created_at, likes_count, view_count, type, subject, url
+FROM club_events
+WHERE type IN ('AJOUNORMAL')
+ORDER BY created_at DESC
+    LIMIT 20;

--- a/src/main/java/com/example/ajouevent_be_v2/domain/clubevent/ClubEvent.java
+++ b/src/main/java/com/example/ajouevent_be_v2/domain/clubevent/ClubEvent.java
@@ -41,6 +41,9 @@ public class ClubEvent {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "content_preview", length = 200)
+    private String contentPreview;
+
     @Column(name = "writer")
     private String writer;
 

--- a/src/main/java/com/example/ajouevent_be_v2/dto/auth/TestLoginResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/auth/TestLoginResponse.java
@@ -1,11 +1,25 @@
 package com.example.ajouevent_be_v2.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "[LOCAL 전용] 테스트 로그인 응답")
 public record TestLoginResponse(
+    @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
     String accessToken,
+
+    @Schema(description = "회원 이름", example = "홍길동")
     String name,
+
+    @Schema(description = "전공", example = "소프트웨어학과")
     String major,
+
+    @Schema(description = "아주대학교 Google 계정 이메일", example = "test@ajou.ac.kr")
     String email,
+
+    @Schema(description = "최초 로그인 여부", example = "false")
     Boolean isNewMember,
+
+    @Schema(description = "FCM 디바이스 토큰", example = "fME9z4k3...")
     String fcmToken
 ) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/CalendarRequest.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/CalendarRequest.java
@@ -1,9 +1,19 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Google Calendar 일정 추가 요청")
 public record CalendarRequest(
+    @Schema(description = "일정 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 신청")
     String summary,
+
+    @Schema(description = "일정 설명 (공지 본문 요약)", example = "장학금 신청 기간: 3월 1일 ~ 3월 15일")
     String description,
+
+    @Schema(description = "일정 시작 날짜 (yyyy-MM-dd)", example = "2024-03-01")
     String startDate,
+
+    @Schema(description = "일정 종료 날짜 (yyyy-MM-dd)", example = "2024-03-15")
     String endDate
 ) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventDetailResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventDetailResponse.java
@@ -1,21 +1,46 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "게시글 상세 조회 응답")
 public record ClubEventDetailResponse(
+    @Schema(description = "게시글 ID", example = "1")
     Long eventId,
+
+    @Schema(description = "게시글 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
     String title,
+
+    @Schema(description = "작성자", example = "소프트웨어학과")
     String writer,
+
+    @Schema(description = "이미지 URL 목록", example = "[\"https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png\"]")
     List<String> imgUrl,
+
+    @Schema(description = "게시글 등록 시각", example = "2024-03-01T10:00:00")
     LocalDateTime createdAt,
+
+    @Schema(description = "찜(좋아요) 수", example = "42")
     Long likesCount,
+
+    @Schema(description = "조회수", example = "128")
     Long viewCount,
-    boolean star, // 찜(like) 여부 — FE 호환을 위해 star 필드명 유지
+
+    @Schema(description = "현재 사용자의 찜 여부", example = "false")
+    boolean star,
+
+    @Schema(description = "게시글 카테고리(토픽) 한국어 이름", example = "소프트웨어학과")
     String subject,
+
+    @Schema(description = "게시글 타입 (ENUM 이름)", example = "AJOUNORMAL")
     String type,
+
+    @Schema(description = "원문 URL", example = "https://www.ajou.ac.kr/kr/ajou/notice.do?mode=view&articleNo=12345")
     String url,
+
+    @Schema(description = "게시글 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
     String content
 ) {
     public static ClubEventDetailResponse from(ClubEvent event, boolean star, List<String> imgUrls) {

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventKeywordPair.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventKeywordPair.java
@@ -1,10 +1,8 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
-import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
-
 /**
  * clubEvent 오케스트레이터에서 keyword와 공지 매핑하는 객체로 사용되는 DTO
  * @param event
  * @param keyword
  */
-public record ClubEventKeywordPair(ClubEvent event, String keyword) {}
+public record ClubEventKeywordPair(ClubEventSummaryResult event, String keyword) {}

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record ClubEventResponse(
     Long eventId,
     String title,
+    String content,
     String writer,
     String imgUrl,
     LocalDateTime createdAt,
@@ -22,6 +23,7 @@ public record ClubEventResponse(
         return new ClubEventResponse(
             event.getEventId(),
             event.getTitle(),
+            event.getContent(),
             event.getWriter(),
             imgUrl,
             event.getCreatedAt(),

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
@@ -48,7 +48,7 @@ public record ClubEventResponse(
         return new ClubEventResponse(
             event.getEventId(),
             event.getTitle(),
-            event.getContent(),
+            event.getContentPreview(),
             event.getWriter(),
             imgUrl,
             event.getCreatedAt(),

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
@@ -1,6 +1,5 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
-import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -43,21 +42,21 @@ public record ClubEventResponse(
     @Schema(description = "원문 URL", example = "https://www.ajou.ac.kr/kr/ajou/notice.do?mode=view&articleNo=12345")
     String url
 ) {
-    public static ClubEventResponse from(ClubEvent event, boolean star, List<String> imgUrls) {
+    public static ClubEventResponse from(ClubEventSummaryResult event, boolean star, List<String> imgUrls) {
         String imgUrl = (imgUrls != null && !imgUrls.isEmpty()) ? imgUrls.get(0) : null;
         return new ClubEventResponse(
-            event.getEventId(),
-            event.getTitle(),
-            event.getContentPreview(),
-            event.getWriter(),
+            event.eventId(),
+            event.title(),
+            event.contentPreview(),
+            event.writer(),
             imgUrl,
-            event.getCreatedAt(),
-            event.getLikesCount(),
-            event.getViewCount(),
+            event.createdAt(),
+            event.likesCount(),
+            event.viewCount(),
             star,
-            event.getSubject(),
-            event.getType() != null ? event.getType().name() : null,
-            event.getUrl()
+            event.subject(),
+            event.type() != null ? event.type().name() : null,
+            event.url()
         );
     }
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
@@ -13,7 +13,7 @@ public record ClubEventResponse(
     @Schema(description = "게시글 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
     String title,
 
-    @Schema(description = "게시글 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
+    @Schema(description = "게시글 본문 미리보기", example = "다음과 같이 장학금 신청을 안내드립니다...")
     String content,
 
     @Schema(description = "작성자", example = "소프트웨어학과")

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventResponse.java
@@ -1,21 +1,46 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "게시글 목록 조회 응답")
 public record ClubEventResponse(
+    @Schema(description = "게시글 ID", example = "1")
     Long eventId,
+
+    @Schema(description = "게시글 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
     String title,
+
+    @Schema(description = "게시글 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
     String content,
+
+    @Schema(description = "작성자", example = "소프트웨어학과")
     String writer,
+
+    @Schema(description = "대표 이미지 URL", example = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png")
     String imgUrl,
+
+    @Schema(description = "게시글 등록 시각", example = "2024-03-01T10:00:00")
     LocalDateTime createdAt,
+
+    @Schema(description = "찜(좋아요) 수", example = "42")
     Long likesCount,
+
+    @Schema(description = "조회수", example = "128")
     Long viewCount,
-    boolean star, // 찜(like) 여부 — FE 호환을 위해 star 필드명 유지
+
+    @Schema(description = "현재 사용자의 찜 여부", example = "false")
+    boolean star,
+
+    @Schema(description = "게시글 카테고리(토픽) 한국어 이름", example = "소프트웨어학과")
     String subject,
+
+    @Schema(description = "게시글 타입 (ENUM 이름)", example = "AJOUNORMAL")
     String type,
+
+    @Schema(description = "원문 URL", example = "https://www.ajou.ac.kr/kr/ajou/notice.do?mode=view&articleNo=12345")
     String url
 ) {
     public static ClubEventResponse from(ClubEvent event, boolean star, List<String> imgUrls) {

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventSummaryResult.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventSummaryResult.java
@@ -1,0 +1,22 @@
+package com.example.ajouevent_be_v2.dto.clubevent;
+
+import com.example.ajouevent_be_v2.domain.clubevent.Type;
+import java.time.LocalDateTime;
+
+/**
+ * 목록 조회 전용 경량 프로젝션.
+ * content(TEXT)를 제외하고 contentPreview(VARCHAR)만 포함해
+ * 오프-페이지 I/O 없이 인라인으로 읽힌다.
+ */
+public record ClubEventSummaryResult(
+    Long eventId,
+    String title,
+    String contentPreview,
+    String writer,
+    LocalDateTime createdAt,
+    Long likesCount,
+    Long viewCount,
+    String subject,
+    Type type,
+    String url
+) {}

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
@@ -1,22 +1,49 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "키워드 구독 게시글 목록 조회 응답")
 public record ClubEventWithKeywordResponse(
+    @Schema(description = "게시글 ID", example = "1")
     Long eventId,
+
+    @Schema(description = "게시글 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
     String title,
+
+    @Schema(description = "게시글 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
     String content,
+
+    @Schema(description = "작성자", example = "소프트웨어학과")
     String writer,
+
+    @Schema(description = "대표 이미지 URL", example = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png")
     String imgUrl,
+
+    @Schema(description = "게시글 등록 시각", example = "2024-03-01T10:00:00")
     LocalDateTime createdAt,
+
+    @Schema(description = "찜(좋아요) 수", example = "42")
     Long likesCount,
+
+    @Schema(description = "조회수", example = "128")
     Long viewCount,
-    boolean star, // 찜(like) 여부 — FE 호환을 위해 star 필드명 유지
+
+    @Schema(description = "현재 사용자의 찜 여부", example = "false")
+    boolean star,
+
+    @Schema(description = "게시글 카테고리(토픽) 한국어 이름", example = "소프트웨어학과")
     String subject,
+
+    @Schema(description = "게시글 타입 (ENUM 이름)", example = "AJOUNORMAL")
     String type,
+
+    @Schema(description = "원문 URL", example = "https://www.ajou.ac.kr/kr/ajou/notice.do?mode=view&articleNo=12345")
     String url,
+
+    @Schema(description = "매칭된 구독 키워드", example = "장학금")
     String keyword
 ) {
     public static ClubEventWithKeywordResponse from(ClubEvent event, String keyword, boolean star, List<String> imgUrls) {

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
@@ -51,7 +51,7 @@ public record ClubEventWithKeywordResponse(
         return new ClubEventWithKeywordResponse(
             event.getEventId(),
             event.getTitle(),
-            event.getContent(),
+            event.getContentPreview(),
             event.getWriter(),
             imgUrl,
             event.getCreatedAt(),

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
@@ -1,6 +1,5 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
-import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,21 +45,22 @@ public record ClubEventWithKeywordResponse(
     @Schema(description = "매칭된 구독 키워드", example = "장학금")
     String keyword
 ) {
-    public static ClubEventWithKeywordResponse from(ClubEvent event, String keyword, boolean star, List<String> imgUrls) {
+    public static ClubEventWithKeywordResponse from(
+            ClubEventSummaryResult event, String keyword, boolean star, List<String> imgUrls) {
         String imgUrl = (imgUrls != null && !imgUrls.isEmpty()) ? imgUrls.get(0) : null;
         return new ClubEventWithKeywordResponse(
-            event.getEventId(),
-            event.getTitle(),
-            event.getContentPreview(),
-            event.getWriter(),
+            event.eventId(),
+            event.title(),
+            event.contentPreview(),
+            event.writer(),
             imgUrl,
-            event.getCreatedAt(),
-            event.getLikesCount(),
-            event.getViewCount(),
+            event.createdAt(),
+            event.likesCount(),
+            event.viewCount(),
             star,
-            event.getSubject(),
-            event.getType() != null ? event.getType().name() : null,
-            event.getUrl(),
+            event.subject(),
+            event.type() != null ? event.type().name() : null,
+            event.url(),
             keyword
         );
     }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
@@ -13,7 +13,7 @@ public record ClubEventWithKeywordResponse(
     @Schema(description = "게시글 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
     String title,
 
-    @Schema(description = "게시글 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
+    @Schema(description = "게시글 본문 미리보기", example = "다음과 같이 장학금 신청을 안내드립니다...")
     String content,
 
     @Schema(description = "작성자", example = "소프트웨어학과")

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/ClubEventWithKeywordResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record ClubEventWithKeywordResponse(
     Long eventId,
     String title,
+    String content,
     String writer,
     String imgUrl,
     LocalDateTime createdAt,
@@ -23,6 +24,7 @@ public record ClubEventWithKeywordResponse(
         return new ClubEventWithKeywordResponse(
             event.getEventId(),
             event.getTitle(),
+            event.getContent(),
             event.getWriter(),
             imgUrl,
             event.getCreatedAt(),

--- a/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/EventBannerResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/clubevent/EventBannerResponse.java
@@ -1,13 +1,24 @@
 package com.example.ajouevent_be_v2.dto.clubevent;
 
 import com.example.ajouevent_be_v2.domain.clubevent.EventBanner;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
+@Schema(description = "홈 화면 이벤트 배너 응답")
 public record EventBannerResponse(
+    @Schema(description = "배너 노출 순서", example = "1")
     Long bannerOrder,
+
+    @Schema(description = "배너 이미지 URL", example = "https://www.ajou.ac.kr/_res/ajou/kr/img/banner/banner-01.png")
     String imgUrl,
+
+    @Schema(description = "배너 클릭 시 이동할 사이트 URL", example = "https://www.ajouevent.com")
     String siteUrl,
+
+    @Schema(description = "배너 노출 시작일", example = "2024-03-01")
     LocalDate startDate,
+
+    @Schema(description = "배너 노출 종료일", example = "2024-03-31")
     LocalDate endDate
 ) {
     public static EventBannerResponse from(EventBanner banner) {

--- a/src/main/java/com/example/ajouevent_be_v2/dto/notification/NotificationClickRequest.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/notification/NotificationClickRequest.java
@@ -1,4 +1,10 @@
 package com.example.ajouevent_be_v2.dto.notification;
 
-public record NotificationClickRequest(Long pushNotificationId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 클릭(읽음 처리) 요청")
+public record NotificationClickRequest(
+    @Schema(description = "읽음 처리할 푸시 알림 ID", example = "1")
+    Long pushNotificationId
+) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/push/PushClusterSendRequest.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/push/PushClusterSendRequest.java
@@ -1,7 +1,13 @@
 package com.example.ajouevent_be_v2.dto.push;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "푸시 클러스터 발송 요청")
 public record PushClusterSendRequest(
+    @Schema(description = "발송할 푸시 클러스터 ID", example = "1")
     Long pushClusterId,
+
+    @Schema(description = "FCM 메시지 발송 명령")
     FcmMessageCommand fcmMessageCommand
 ) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/webhook/CrawlingTokenResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/webhook/CrawlingTokenResponse.java
@@ -1,4 +1,10 @@
 package com.example.ajouevent_be_v2.dto.webhook;
 
-public record CrawlingTokenResponse(String crawlingToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "크롤링 인증 토큰 발급 응답")
+public record CrawlingTokenResponse(
+    @Schema(description = "발급된 크롤링 인증 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+    String crawlingToken
+) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/dto/webhook/WebhookRequest.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/webhook/WebhookRequest.java
@@ -1,19 +1,38 @@
 package com.example.ajouevent_be_v2.dto.webhook;
 
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "크롤러에서 전달하는 공지 등록 웹훅 요청")
 public record WebhookRequest(
-        String title,
-        String content,
-        String category,
-        String department,
-        String englishTopic,
-        String koreanTopic,
-        String url,
-        List<String> images,
-        LocalDateTime date
+    @Schema(description = "공지 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
+    String title,
+
+    @Schema(description = "공지 본문 내용", example = "다음과 같이 장학금 신청을 안내드립니다.")
+    String content,
+
+    @Schema(description = "공지 카테고리", example = "scholarship")
+    String category,
+
+    @Schema(description = "작성 학과 영문 식별자", example = "Software")
+    String department,
+
+    @Schema(description = "토픽 영문 식별자", example = "AJOUNORMAL")
+    String englishTopic,
+
+    @Schema(description = "토픽 한국어 이름", example = "소프트웨어학과")
+    String koreanTopic,
+
+    @Schema(description = "원문 URL", example = "https://www.ajou.ac.kr/kr/ajou/notice.do?mode=view&articleNo=12345")
+    String url,
+
+    @Schema(description = "첨부 이미지 URL 목록")
+    List<String> images,
+
+    @Schema(description = "공지 등록 시각", example = "2024-03-01T10:00:00")
+    LocalDateTime date
 ) {
 
     public ClubEventCommand toClubEventCommand() {

--- a/src/main/java/com/example/ajouevent_be_v2/dto/webhook/WebhookResponse.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/webhook/WebhookResponse.java
@@ -1,9 +1,19 @@
 package com.example.ajouevent_be_v2.dto.webhook;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공지 등록 웹훅 처리 결과 응답")
 public record WebhookResponse(
-        String result,
-        String topic,
-        String title,
-        Long eventId
+    @Schema(description = "처리 결과 메시지", example = "success")
+    String result,
+
+    @Schema(description = "등록된 토픽 이름", example = "소프트웨어학과")
+    String topic,
+
+    @Schema(description = "등록된 공지 제목", example = "[소프트웨어학과] 2024학년도 1학기 장학금 공지")
+    String title,
+
+    @Schema(description = "생성된 게시글 ID", example = "1")
+    Long eventId
 ) {
 }

--- a/src/main/java/com/example/ajouevent_be_v2/orchestrator/ClubEventOrchestrator.java
+++ b/src/main/java/com/example/ajouevent_be_v2/orchestrator/ClubEventOrchestrator.java
@@ -8,13 +8,7 @@ import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.domain.keyword.Keyword;
 import com.example.ajouevent_be_v2.domain.keyword.KeywordMember;
 import com.example.ajouevent_be_v2.domain.member.Member;
-import com.example.ajouevent_be_v2.dto.clubevent.CalendarRequest;
-import com.example.ajouevent_be_v2.dto.clubevent.ClubEventCommand;
-import com.example.ajouevent_be_v2.dto.clubevent.ClubEventDetailResponse;
-import com.example.ajouevent_be_v2.dto.clubevent.ClubEventKeywordPair;
-import com.example.ajouevent_be_v2.dto.clubevent.ClubEventResponse;
-import com.example.ajouevent_be_v2.dto.clubevent.ClubEventWithKeywordResponse;
-import com.example.ajouevent_be_v2.dto.clubevent.EventBannerResponse;
+import com.example.ajouevent_be_v2.dto.clubevent.*;
 import com.example.ajouevent_be_v2.service.calendar.CalendarCommandService;
 import com.example.ajouevent_be_v2.service.clubevent.ClubEventCommandService;
 import com.example.ajouevent_be_v2.service.clubevent.ClubEventLikeCommandService;
@@ -102,7 +96,7 @@ public class ClubEventOrchestrator {
         if (eventType.isEmpty()) {
             return SliceResponse.empty(pageable.getPageNumber());
         }
-        SliceResult<ClubEvent> result = clubEventQueryService.getEventsByType(eventType.get(), keyword, pageable);
+        SliceResult<ClubEventSummaryResult> result = clubEventQueryService.getEventsByType(eventType.get(), keyword, pageable);
         if (member != null) {
             topicCommandService.markTopicAsRead(member, eventType.get().getEnglishTopic());
         }
@@ -117,12 +111,12 @@ public class ClubEventOrchestrator {
      * 2. 이미지·찜 여부 조립 후 반환
      */
     public List<ClubEventResponse> getTopPopularEvents(Member member) {
-        List<ClubEvent> events = clubEventQueryService.getPopularEvents();
-        List<Long> eventIds = events.stream().map(ClubEvent::getEventId).toList();
+        List<ClubEventSummaryResult> events = clubEventQueryService.getPopularEvents();
+        List<Long> eventIds = events.stream().map(ClubEventSummaryResult::eventId).toList();
         Map<Long, List<String>> images = clubEventQueryService.getImageUrlsByEventIds(eventIds);
         Set<Long> likedIds = clubEventLikeQueryService.getLikedEventIds(member);
         return events.stream()
-            .map(e -> ClubEventResponse.from(e, likedIds.contains(e.getEventId()), images.get(e.getEventId())))
+            .map(e -> ClubEventResponse.from(e, likedIds.contains(e.eventId()), images.get(e.eventId())))
             .toList();
     }
 
@@ -144,7 +138,7 @@ public class ClubEventOrchestrator {
         if (subscribedTypes.isEmpty()) {
             return SliceResponse.empty(pageable.getPageNumber());
         }
-        SliceResult<ClubEvent> result = clubEventQueryService.getEventsByTypes(subscribedTypes, keyword, pageable);
+        SliceResult<ClubEventSummaryResult> result = clubEventQueryService.getEventsByTypes(subscribedTypes, keyword, pageable);
         return buildClubEventSlice(result, member);
     }
 
@@ -168,9 +162,9 @@ public class ClubEventOrchestrator {
         if (hasTypeFilter && resolvedType.isEmpty()) {
             return SliceResponse.empty(pageable.getPageNumber());
         }
-        SliceResult<ClubEvent> result = clubEventQueryService.getEventsByIds(likedEventIds, resolvedType.orElse(null), keyword, pageable);
+        SliceResult<ClubEventSummaryResult> result = clubEventQueryService.getEventsByIds(likedEventIds, resolvedType.orElse(null), keyword, pageable);
         Map<Long, List<String>> images = clubEventQueryService.getImageUrlsByEventIds(toEventIds(result));
-        return SliceResponse.from(result, e -> ClubEventResponse.from(e, true, images.get(e.getEventId())));
+        return SliceResponse.from(result, e -> ClubEventResponse.from(e, true, images.get(e.eventId())));
     }
 
     /**
@@ -198,16 +192,16 @@ public class ClubEventOrchestrator {
         boolean hasNext = false;
 
         for (Map.Entry<Type, List<Keyword>> entry : keywordsByType.entrySet()) {
-            SliceResult<ClubEvent> result = clubEventQueryService.getEventsByTypeAndKeywords(
+            SliceResult<ClubEventSummaryResult> result = clubEventQueryService.getEventsByTypeAndKeywords(
                 entry.getKey(), entry.getValue(), pageable);
             List<String> lowerKeywords = toLowerKeywords(entry.getValue());
-            for (ClubEvent event : result.result()) {
+            for (ClubEventSummaryResult event : result.result()) {
                 findFirstMatchingKeyword(event, entry.getValue(), lowerKeywords).ifPresent(allPairs::add);
             }
             if (result.hasNext()) hasNext = true;
         }
 
-        List<Long> eventIds = allPairs.stream().map(p -> p.event().getEventId()).distinct().toList();
+        List<Long> eventIds = allPairs.stream().map(p -> p.event().eventId()).distinct().toList();
         Map<Long, List<String>> images = clubEventQueryService.getImageUrlsByEventIds(eventIds);
         Set<Long> likedIds = clubEventLikeQueryService.getLikedEventIds(member);
 
@@ -230,11 +224,11 @@ public class ClubEventOrchestrator {
     public SliceResponse<ClubEventWithKeywordResponse> getByKeyword(String searchKeyword, Member member, Pageable pageable) {
         Keyword keyword = keywordQueryService.getSubscribedKeywordByName(member, searchKeyword);
         keywordCommandService.markKeywordMemberAsRead(member, keyword);
-        SliceResult<ClubEvent> result = clubEventQueryService.getEventsByKeyword(keyword, pageable);
+        SliceResult<ClubEventSummaryResult> result = clubEventQueryService.getEventsByKeyword(keyword, pageable);
         Map<Long, List<String>> images = clubEventQueryService.getImageUrlsByEventIds(toEventIds(result));
         Set<Long> likedIds = clubEventLikeQueryService.getLikedEventIds(member);
         return SliceResponse.from(result, e -> ClubEventWithKeywordResponse.from(
-            e, keyword.getKoreanKeyword(), likedIds.contains(e.getEventId()), images.get(e.getEventId())));
+            e, keyword.getKoreanKeyword(), likedIds.contains(e.eventId()), images.get(e.eventId())));
     }
 
     /**
@@ -284,10 +278,10 @@ public class ClubEventOrchestrator {
      * 이미지 배치 조회 + 찜 여부 조회 + SliceResponse 조립을 한 번에 처리한다.
      * getEventTypeList / getSubscribedEvents 처럼 "일반 목록 조회" 패턴에서 공통으로 사용한다.
      */
-    private SliceResponse<ClubEventResponse> buildClubEventSlice(SliceResult<ClubEvent> result, Member member) {
+    private SliceResponse<ClubEventResponse> buildClubEventSlice(SliceResult<ClubEventSummaryResult> result, Member member) {
         Map<Long, List<String>> images = clubEventQueryService.getImageUrlsByEventIds(toEventIds(result));
         Set<Long> likedIds = clubEventLikeQueryService.getLikedEventIds(member);
-        return SliceResponse.from(result, e -> ClubEventResponse.from(e, likedIds.contains(e.getEventId()), images.get(e.getEventId())));
+        return SliceResponse.from(result, e -> ClubEventResponse.from(e, likedIds.contains(e.eventId()), images.get(e.eventId())));
     }
 
     /**
@@ -297,9 +291,9 @@ public class ClubEventOrchestrator {
      * @param lowerKeywords 반복 toLowerCase 호출을 피하기 위해 미리 소문자로 변환한 키워드 목록
      */
     private Optional<ClubEventKeywordPair> findFirstMatchingKeyword(
-        ClubEvent event, List<Keyword> keywords, List<String> lowerKeywords) {
-        if (event.getTitle() == null) return Optional.empty();
-        String lowerTitle = event.getTitle().toLowerCase();
+            ClubEventSummaryResult event, List<Keyword> keywords, List<String> lowerKeywords) {
+        if (event.title() == null) return Optional.empty();
+        String lowerTitle = event.title().toLowerCase();
         for (int i = 0; i < lowerKeywords.size(); i++) {
             if (lowerTitle.contains(lowerKeywords.get(i))) {
                 return Optional.of(new ClubEventKeywordPair(event, keywords.get(i).getKoreanKeyword()));
@@ -315,19 +309,19 @@ public class ClubEventOrchestrator {
             .toList();
     }
 
-    private List<Long> toEventIds(SliceResult<ClubEvent> result) {
-        return result.result().stream().map(ClubEvent::getEventId).toList();
+    private List<Long> toEventIds(SliceResult<ClubEventSummaryResult> result) {
+        return result.result().stream().map(ClubEventSummaryResult::eventId).toList();
     }
 
     private List<ClubEventWithKeywordResponse> toKeywordResponses(
         List<ClubEventKeywordPair> pairs, Set<Long> likedIds, Map<Long, List<String>> images) {
         return pairs.stream()
-            .sorted(Comparator.comparing(pair -> pair.event().getCreatedAt(), Comparator.reverseOrder()))
+            .sorted(Comparator.comparing(pair -> pair.event().createdAt(), Comparator.reverseOrder()))
             .map(pair -> ClubEventWithKeywordResponse.from(
                 pair.event(),
                 pair.keyword(),
-                likedIds.contains(pair.event().getEventId()),
-                images.get(pair.event().getEventId())))
+                likedIds.contains(pair.event().eventId()),
+                images.get(pair.event().eventId())))
             .toList();
     }
 

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJpaRepositoryAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJpaRepositoryAdapter.java
@@ -3,8 +3,10 @@ package com.example.ajouevent_be_v2.repository.adapter.clubevent;
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.domain.keyword.Keyword;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,36 +16,108 @@ import org.springframework.data.repository.query.Param;
 
 public interface ClubEventJpaRepositoryAdapter extends JpaRepository<ClubEvent, Long> {
 
-    Slice<ClubEvent> findByTypeAndTitleContaining(Type type, String keyword, Pageable pageable);
-
-    Slice<ClubEvent> findByTypeIn(List<Type> types, Pageable pageable);
-
-    Slice<ClubEvent> findByTypeInAndTitleContaining(List<Type> types, String keyword, Pageable pageable);
-
-    @Query("SELECT ce FROM ClubEvent ce WHERE ce.eventId IN :eventIds ORDER BY ce.createdAt DESC")
-    Slice<ClubEvent> findByEventIds(@Param("eventIds") List<Long> eventIds, Pageable pageable);
-
-    Slice<ClubEvent> findByEventIdInAndType(List<Long> eventId, Type type, Pageable pageable);
-
-    Slice<ClubEvent> findByEventIdInAndTitleContaining(List<Long> eventId, String title, Pageable pageable);
-
-    Slice<ClubEvent> findByEventIdInAndTypeAndTitleContaining(
-        List<Long> eventId, Type type, String title, Pageable pageable);
-
-    List<ClubEvent> findTop10ByCreatedAtBetweenOrderByViewCountDesc(
-        LocalDateTime startOfWeek, LocalDateTime endOfWeek);
-
-    List<ClubEvent> findTop10ByTypeOrderByCreatedAtDesc(Type type);
+    // ── 공통 SELECT 절 (content 제외, contentPreview 포함) ──────────────────
+    // SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult(
+    //     ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,
+    //     ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url)
 
     @Query(
-        "SELECT ce FROM ClubEvent ce "
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.type = :type AND ce.title LIKE CONCAT('%', :keyword, '%')")
+    Slice<ClubEventSummaryResult> findByTypeAndTitleContaining(
+        @Param("type") Type type, @Param("keyword") String keyword, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.type IN :types")
+    Slice<ClubEventSummaryResult> findByTypeIn(@Param("types") List<Type> types, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.type IN :types AND ce.title LIKE CONCAT('%', :keyword, '%')")
+    Slice<ClubEventSummaryResult> findByTypeInAndTitleContaining(
+        @Param("types") List<Type> types, @Param("keyword") String keyword, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.eventId IN :eventIds ORDER BY ce.createdAt DESC")
+    Slice<ClubEventSummaryResult> findByEventIds(@Param("eventIds") List<Long> eventIds, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.eventId IN :eventIds AND ce.type = :type")
+    Slice<ClubEventSummaryResult> findByEventIdInAndType(
+        @Param("eventIds") List<Long> eventIds, @Param("type") Type type, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.eventId IN :eventIds AND ce.title LIKE CONCAT('%', :title, '%')")
+    Slice<ClubEventSummaryResult> findByEventIdInAndTitleContaining(
+        @Param("eventIds") List<Long> eventIds, @Param("title") String title, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.eventId IN :eventIds AND ce.type = :type "
+            + "AND ce.title LIKE CONCAT('%', :title, '%')")
+    Slice<ClubEventSummaryResult> findByEventIdInAndTypeAndTitleContaining(
+        @Param("eventIds") List<Long> eventIds,
+        @Param("type") Type type,
+        @Param("title") String title,
+        Pageable pageable);
+
+    // Top10 — Pageable(size=10) 로 제한, ORDER BY 는 쿼리에 명시
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.createdAt BETWEEN :start AND :end "
+            + "ORDER BY ce.viewCount DESC")
+    List<ClubEventSummaryResult> findTop10ByCreatedAtBetween(
+        @Param("start") LocalDateTime start, @Param("end") LocalDateTime end, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
+            + "WHERE ce.type = :type "
+            + "ORDER BY ce.createdAt DESC")
+    List<ClubEventSummaryResult> findTop10ByType(@Param("type") Type type, Pageable pageable);
+
+    @Query(
+        "SELECT new com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult("
+            + "ce.eventId, ce.title, ce.contentPreview, ce.writer, ce.createdAt,"
+            + "ce.likesCount, ce.viewCount, ce.subject, ce.type, ce.url) "
+            + "FROM ClubEvent ce "
             + "WHERE ce.type = :type "
             + "AND EXISTS ("
             + "SELECT 1 FROM Keyword k "
             + "WHERE k IN :keywords "
             + "AND LOWER(ce.title) LIKE CONCAT('%', LOWER(k.koreanKeyword), '%')) "
             + "ORDER BY ce.createdAt DESC")
-    Slice<ClubEvent> findByTypeAndAnyKeyword(
+    Slice<ClubEventSummaryResult> findByTypeAndAnyKeyword(
         @Param("type") Type type, @Param("keywords") List<Keyword> keywords, Pageable pageable);
 
     @Modifying

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
@@ -3,11 +3,13 @@ package com.example.ajouevent_be_v2.repository.port.clubevent;
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.domain.keyword.Keyword;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import com.example.ajouevent_be_v2.repository.adapter.clubevent.ClubEventJpaRepositoryAdapter;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
@@ -26,46 +28,47 @@ public class ClubEventRepositoryPort {
         return clubEventJpaRepositoryAdapter.save(clubEvent);
     }
 
-    public Slice<ClubEvent> findByTypeAndTitleContaining(Type type, String keyword, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByTypeAndTitleContaining(Type type, String keyword, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByTypeAndTitleContaining(type, keyword, pageable);
     }
 
-    public Slice<ClubEvent> findByTypeIn(List<Type> types, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByTypeIn(List<Type> types, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByTypeIn(types, pageable);
     }
 
-    public Slice<ClubEvent> findByTypeInAndTitleContaining(List<Type> types, String keyword, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByTypeInAndTitleContaining(List<Type> types, String keyword, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByTypeInAndTitleContaining(types, keyword, pageable);
     }
 
-    public Slice<ClubEvent> findByEventIds(List<Long> eventIds, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByEventIds(List<Long> eventIds, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByEventIds(eventIds, pageable);
     }
 
-    public Slice<ClubEvent> findByEventIdsAndType(List<Long> eventIds, Type type, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByEventIdsAndType(List<Long> eventIds, Type type, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByEventIdInAndType(eventIds, type, pageable);
     }
 
-    public Slice<ClubEvent> findByEventIdsAndTitleContaining(
+    public Slice<ClubEventSummaryResult> findByEventIdsAndTitleContaining(
         List<Long> eventIds, String keyword, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByEventIdInAndTitleContaining(eventIds, keyword, pageable);
     }
 
-    public Slice<ClubEvent> findByEventIdsAndTypeAndTitleContaining(
+    public Slice<ClubEventSummaryResult> findByEventIdsAndTypeAndTitleContaining(
         List<Long> eventIds, Type type, String keyword, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByEventIdInAndTypeAndTitleContaining(
             eventIds, type, keyword, pageable);
     }
 
-    public List<ClubEvent> findTop10ByCreatedAtBetween(LocalDateTime start, LocalDateTime end) {
-        return clubEventJpaRepositoryAdapter.findTop10ByCreatedAtBetweenOrderByViewCountDesc(start, end);
+    public List<ClubEventSummaryResult> findTop10ByCreatedAtBetween(LocalDateTime start, LocalDateTime end) {
+        return clubEventJpaRepositoryAdapter.findTop10ByCreatedAtBetween(
+            start, end, PageRequest.of(0, 10));
     }
 
-    public List<ClubEvent> findTop10ByTypeOrderByCreatedAtDesc(Type type) {
-        return clubEventJpaRepositoryAdapter.findTop10ByTypeOrderByCreatedAtDesc(type);
+    public List<ClubEventSummaryResult> findTop10ByType(Type type) {
+        return clubEventJpaRepositoryAdapter.findTop10ByType(type, PageRequest.of(0, 10));
     }
 
-    public Slice<ClubEvent> findByTypeAndAnyKeyword(Type type, List<Keyword> keywords, Pageable pageable) {
+    public Slice<ClubEventSummaryResult> findByTypeAndAnyKeyword(Type type, List<Keyword> keywords, Pageable pageable) {
         return clubEventJpaRepositoryAdapter.findByTypeAndAnyKeyword(type, keywords, pageable);
     }
 

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubEventCommandService {
 
     private static final String DEFAULT_IMAGE_URL = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png";
+    private static final int CONTENT_PREVIEW_LENGTH = 200;
 
     private final ClubEventRepositoryPort clubEventRepositoryPort;
 
@@ -40,9 +41,15 @@ public class ClubEventCommandService {
         Type type = parseType(command.englishTopic());
         List<String> imageUrls = resolveImages(command.images());
 
+        String content = command.content();
+        String contentPreview = content != null && content.length() > CONTENT_PREVIEW_LENGTH
+                ? content.substring(0, CONTENT_PREVIEW_LENGTH)
+                : content;
+
         ClubEvent clubEvent = ClubEvent.builder()
                 .title(command.title())
-                .content(command.content())
+                .content(content)
+                .contentPreview(contentPreview)
                 .writer(command.department())
                 .subject(command.koreanTopic())
                 .url(command.url())

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
@@ -6,6 +6,7 @@ import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import com.example.ajouevent_be_v2.domain.clubevent.ClubEventImage;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventCommand;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -27,10 +28,10 @@ public class ClubEventCommandService {
 
     public void isDuplicateNotice(String englishTopic, String title, String url) {
         Type type = parseType(englishTopic);
-        List<ClubEvent> recentEvents = clubEventRepositoryPort.findTop10ByTypeOrderByCreatedAtDesc(type);
+        List<ClubEventSummaryResult> recentEvents = clubEventRepositoryPort.findTop10ByType(type);
 
         boolean isDuplicate = recentEvents.stream()
-                .anyMatch(e -> e.getTitle().equals(title) && e.getUrl().equals(url));
+                .anyMatch(e -> e.title().equals(title) && e.url().equals(url));
         if (isDuplicate) {
             throw new ClubEventException(ClubEventErrorCode.DUPLICATE_NOTICE);
         }

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
@@ -8,6 +8,7 @@ import com.example.ajouevent_be_v2.domain.clubevent.EventBanner;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.domain.keyword.Keyword;
 import com.example.ajouevent_be_v2.domain.member.Member;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventImageRepositoryPort;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
@@ -58,31 +59,31 @@ public class ClubEventQueryService {
         }
     }
 
-    public SliceResult<ClubEvent> getEventsByType(Type type, String keyword, Pageable pageable) {
+    public SliceResult<ClubEventSummaryResult> getEventsByType(Type type, String keyword, Pageable pageable) {
         String searchKeyword = keyword != null ? keyword : "";
-        Slice<ClubEvent> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
+        Slice<ClubEventSummaryResult> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
             type, searchKeyword, pageable);
         return SliceResult.from(slice, pageable);
     }
 
-    public List<ClubEvent> getPopularEvents() {
+    public List<ClubEventSummaryResult> getPopularEvents() {
         LocalDate now = LocalDate.now();
         LocalDateTime start = now.with(DayOfWeek.MONDAY).atStartOfDay();
         LocalDateTime end = now.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX);
         return clubEventRepositoryPort.findTop10ByCreatedAtBetween(start, end);
     }
 
-    public SliceResult<ClubEvent> getEventsByTypes(List<Type> types, String keyword, Pageable pageable) {
+    public SliceResult<ClubEventSummaryResult> getEventsByTypes(List<Type> types, String keyword, Pageable pageable) {
         String searchKeyword = keyword != null ? keyword : "";
-        Slice<ClubEvent> slice = searchKeyword.isEmpty()
+        Slice<ClubEventSummaryResult> slice = searchKeyword.isEmpty()
             ? clubEventRepositoryPort.findByTypeIn(types, pageable)
             : clubEventRepositoryPort.findByTypeInAndTitleContaining(types, searchKeyword, pageable);
         return SliceResult.from(slice, pageable);
     }
 
-    public SliceResult<ClubEvent> getEventsByIds(List<Long> eventIds, Type type, String keyword, Pageable pageable) {
+    public SliceResult<ClubEventSummaryResult> getEventsByIds(List<Long> eventIds, Type type, String keyword, Pageable pageable) {
         String searchKeyword = keyword != null ? keyword : "";
-        Slice<ClubEvent> slice;
+        Slice<ClubEventSummaryResult> slice;
         if (type != null && !searchKeyword.isEmpty()) {
             slice = clubEventRepositoryPort.findByEventIdsAndTypeAndTitleContaining(eventIds, type, searchKeyword, pageable);
         } else if (type != null) {
@@ -95,9 +96,9 @@ public class ClubEventQueryService {
         return SliceResult.from(slice, pageable);
     }
 
-    public SliceResult<ClubEvent> getEventsByKeyword(Keyword keyword, Pageable pageable) {
+    public SliceResult<ClubEventSummaryResult> getEventsByKeyword(Keyword keyword, Pageable pageable) {
         Type type = keyword.getTopic().getType();
-        Slice<ClubEvent> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
+        Slice<ClubEventSummaryResult> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
             type, keyword.getKoreanKeyword(), pageable);
         return SliceResult.from(slice, pageable);
     }
@@ -106,8 +107,8 @@ public class ClubEventQueryService {
         return eventBannerRepositoryPort.findAllOrderByBannerOrder();
     }
 
-    public SliceResult<ClubEvent> getEventsByTypeAndKeywords(Type type, List<Keyword> keywords, Pageable pageable) {
-        Slice<ClubEvent> slice = clubEventRepositoryPort.findByTypeAndAnyKeyword(type, keywords, pageable);
+    public SliceResult<ClubEventSummaryResult> getEventsByTypeAndKeywords(Type type, List<Keyword> keywords, Pageable pageable) {
+        Slice<ClubEventSummaryResult> slice = clubEventRepositoryPort.findByTypeAndAnyKeyword(type, keywords, pageable);
         return SliceResult.from(slice, pageable);
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -212,8 +212,8 @@ CREATE TABLE IF NOT EXISTS push_clusters (
 -- findAllByPushClusterWithMember
 --   → idx_pct_push_cluster_id (push_cluster_id)
 -- findRecoverableTokens — OR 조건 3개를 각 인덱스로 개별 커버
---   PENDING      AND request_time   < ?  → idx_pct_status_request_time   (job_status, request_time)
---   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed_time (job_status, processed_time)
+--   PENDING      AND request_time   < ?  → idx_pct_status_request        (job_status, request_time)
+--   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed      (job_status, processed_time)
 --   RETRY_PENDING AND retry_after <= ? AND retry_count <= ?
 --                                        → idx_pct_status_retry          (job_status, retry_after, retry_count)
 CREATE TABLE IF NOT EXISTS push_cluster_tokens (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -26,18 +26,28 @@ CREATE TABLE IF NOT EXISTS tokens (
 );
 
 -- topics
+-- findFirstByDepartment        → idx_topics_department
+-- findByKoreanTopic            → idx_topics_korean_topic
 CREATE TABLE IF NOT EXISTS topics (
-    id            BIGINT       NOT NULL AUTO_INCREMENT,
-    department    VARCHAR(255),
-    type          VARCHAR(100),
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    department     VARCHAR(255),
+    type           VARCHAR(100),
     classification VARCHAR(255),
-    korean_topic  VARCHAR(255),
-    korean_order  BIGINT,
+    korean_topic   VARCHAR(255),
+    korean_order   BIGINT,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_topics_type (type)
+    UNIQUE KEY uq_topics_type (type),
+    INDEX idx_topics_department  (department),
+    INDEX idx_topics_korean_topic (korean_topic)
 );
 
 -- topic_members
+-- existsByTopicAndMember / findByMemberAndTopic / deleteByTopicAndMember
+--   → uq_topic_members (member_id, topic_id)  — unique + leading prefix (member_id) 커버
+-- existsByMemberAndIsReadFalse
+--   → idx_topic_members_member_isread (member_id, is_read)
+-- findByTopicWithMemberAndReceiveNotificationTrue (push 발송 라우팅 핵심 쿼리)
+--   → idx_topic_members_topic_notification (topic_id, receive_notification)
 CREATE TABLE IF NOT EXISTS topic_members (
     id                   BIGINT     NOT NULL AUTO_INCREMENT,
     topic_id             BIGINT,
@@ -46,20 +56,30 @@ CREATE TABLE IF NOT EXISTS topic_members (
     last_read_at         DATETIME   NOT NULL,
     receive_notification TINYINT(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
+    UNIQUE KEY uq_topic_members (member_id, topic_id),
+    INDEX idx_topic_members_member_isread      (member_id, is_read),
+    INDEX idx_topic_members_topic_notification (topic_id, receive_notification),
     CONSTRAINT fk_topic_members_topic  FOREIGN KEY (topic_id)  REFERENCES topics  (id),
     CONSTRAINT fk_topic_members_member FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
 -- topic_tokens
+-- deleteByTopicAndTokenValues  → idx_topic_tokens_topic_token (topic_id, token_value)
+-- deleteAllByTokenValues       → idx_topic_tokens_token_value (token_value)
 CREATE TABLE IF NOT EXISTS topic_tokens (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     topic_id    BIGINT,
     token_value VARCHAR(255),
     PRIMARY KEY (id),
+    INDEX idx_topic_tokens_topic_token (topic_id, token_value),
+    INDEX idx_topic_tokens_token_value (token_value),
     CONSTRAINT fk_topic_tokens_topic FOREIGN KEY (topic_id) REFERENCES topics (id)
 );
 
 -- keywords
+-- findByEncodedKeyword         → uq_keywords_encoded_keyword (encoded_keyword)
+-- findBySearchKeyword          → idx_keywords_search_keyword (search_keyword)
+-- findByTopic                  → idx_keywords_topic_id (topic_id)
 CREATE TABLE IF NOT EXISTS keywords (
     id               BIGINT       NOT NULL AUTO_INCREMENT,
     encoded_keyword  VARCHAR(255),
@@ -67,10 +87,19 @@ CREATE TABLE IF NOT EXISTS keywords (
     search_keyword   VARCHAR(255),
     topic_id         BIGINT,
     PRIMARY KEY (id),
+    UNIQUE KEY uq_keywords_encoded_keyword (encoded_keyword),
+    INDEX idx_keywords_search_keyword (search_keyword),
+    INDEX idx_keywords_topic_id       (topic_id),
     CONSTRAINT fk_keywords_topic FOREIGN KEY (topic_id) REFERENCES topics (id)
 );
 
 -- keyword_members
+-- existsByKeywordAndMember / findByKeywordAndMemberAndIsReadFalse / deleteByKeywordAndMember
+--   → uq_keyword_members (member_id, keyword_id)  — unique + leading prefix 커버
+-- existsByMemberAndIsReadFalse
+--   → idx_keyword_members_member_isread (member_id, is_read)
+-- findByKeywordWithMember
+--   → idx_keyword_members_keyword_id (keyword_id)
 CREATE TABLE IF NOT EXISTS keyword_members (
     id           BIGINT     NOT NULL AUTO_INCREMENT,
     keyword_id   BIGINT,
@@ -78,38 +107,55 @@ CREATE TABLE IF NOT EXISTS keyword_members (
     is_read      TINYINT(1) NOT NULL DEFAULT 0,
     last_read_at DATETIME   NOT NULL,
     PRIMARY KEY (id),
+    UNIQUE KEY uq_keyword_members (member_id, keyword_id),
+    INDEX idx_keyword_members_member_isread (member_id, is_read),
+    INDEX idx_keyword_members_keyword_id    (keyword_id),
     CONSTRAINT fk_keyword_members_keyword FOREIGN KEY (keyword_id) REFERENCES keywords (id),
     CONSTRAINT fk_keyword_members_member  FOREIGN KEY (member_id)  REFERENCES members  (id)
 );
 
 -- keyword_tokens
+-- deleteByKeywordAndTokenValues  → idx_keyword_tokens_keyword_token (keyword_id, token_value)
+-- deleteAllByTokenValues / findKeywordTokensWithKeyword
+--   → idx_keyword_tokens_token_value (token_value)
 CREATE TABLE IF NOT EXISTS keyword_tokens (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     keyword_id  BIGINT,
     token_value VARCHAR(255),
     PRIMARY KEY (id),
+    INDEX idx_keyword_tokens_keyword_token (keyword_id, token_value),
+    INDEX idx_keyword_tokens_token_value   (token_value),
     CONSTRAINT fk_keyword_tokens_keyword FOREIGN KEY (keyword_id) REFERENCES keywords (id)
 );
 
 -- club_events
+-- findByTypeIn / findByTypeInAndTitleContaining / findTop10ByTypeOrderByCreatedAtDesc
+-- findByTypeAndAnyKeyword
+--   → idx_club_events_type_createdat (type, created_at)
+--     type 필터 후 created_at DESC 정렬까지 인덱스 커버
+-- findTop10ByCreatedAtBetweenOrderByViewCountDesc (주간 트렌딩)
+--   → idx_club_events_createdat_viewcount (created_at, view_count)
 CREATE TABLE IF NOT EXISTS club_events (
-    event_id    BIGINT        NOT NULL AUTO_INCREMENT,
-    title       VARCHAR(255),
-    content     TEXT,
-    writer      VARCHAR(255),
-    created_at  DATETIME,
-    subject     VARCHAR(255),
-    url         VARCHAR(255),
-    likes_count BIGINT        NOT NULL DEFAULT 0,
-    view_count  BIGINT        NOT NULL DEFAULT 0,
-    type        VARCHAR(100),
-    PRIMARY KEY (event_id)
+    event_id         BIGINT        NOT NULL AUTO_INCREMENT,
+    title            VARCHAR(255),
+    content          TEXT,
+    content_preview  VARCHAR(200),
+    writer           VARCHAR(255),
+    created_at       DATETIME,
+    subject          VARCHAR(255),
+    url              VARCHAR(255),
+    likes_count      BIGINT        NOT NULL DEFAULT 0,
+    view_count       BIGINT        NOT NULL DEFAULT 0,
+    type             VARCHAR(100),
+    PRIMARY KEY (event_id),
+    INDEX idx_club_events_type_createdat     (type, created_at),
+    INDEX idx_club_events_createdat_viewcount (created_at, view_count)
 );
 
 -- club_event_images
 CREATE TABLE IF NOT EXISTS club_event_images (
-    image_id     BIGINT       NOT NULL AUTO_INCREMENT,
-    url          VARCHAR(255),
+    image_id      BIGINT       NOT NULL AUTO_INCREMENT,
+    url           VARCHAR(255),
     club_event_id BIGINT,
     PRIMARY KEY (image_id),
     CONSTRAINT fk_club_event_images_club_event FOREIGN KEY (club_event_id) REFERENCES club_events (event_id)
@@ -127,53 +173,77 @@ CREATE TABLE IF NOT EXISTS event_banners (
 );
 
 -- event_likes
+-- existsByMemberAndClubEvent / findByClubEventAndMember / deleteByMemberAndClubEvent
+--   → uq_event_likes (member_id, club_event_id) — unique + leading prefix(member_id) 커버
 CREATE TABLE IF NOT EXISTS event_likes (
     event_like_id BIGINT NOT NULL AUTO_INCREMENT,
     club_event_id BIGINT,
     member_id     BIGINT,
     PRIMARY KEY (event_like_id),
+    UNIQUE KEY uq_event_likes (member_id, club_event_id),
     CONSTRAINT fk_event_likes_club_event FOREIGN KEY (club_event_id) REFERENCES club_events (event_id),
     CONSTRAINT fk_event_likes_member     FOREIGN KEY (member_id)     REFERENCES members    (id)
 );
 
 -- push_clusters
+-- findAllByJobStatus            → idx_push_clusters_job_status (job_status)
 CREATE TABLE IF NOT EXISTS push_clusters (
-    id             BIGINT       NOT NULL AUTO_INCREMENT,
-    club_event_id  BIGINT,
-    title          VARCHAR(255) NOT NULL,
-    body           VARCHAR(255) NOT NULL,
-    image_url      VARCHAR(255) NOT NULL,
-    click_url      VARCHAR(255) NOT NULL,
-    job_status     VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
-    total_count    INT          NOT NULL DEFAULT 0,
-    registered_at  DATETIME     NOT NULL,
-    success_count        INT          NOT NULL DEFAULT 0,
-    fail_count           INT          NOT NULL DEFAULT 0,
-    start_at             DATETIME,
-    end_at               DATETIME,
-    retry_success_count  INT          NOT NULL DEFAULT 0,
-    retry_fail_count     INT          NOT NULL DEFAULT 0,
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    club_event_id       BIGINT,
+    title               VARCHAR(255) NOT NULL,
+    body                VARCHAR(255) NOT NULL,
+    image_url           VARCHAR(255) NOT NULL,
+    click_url           VARCHAR(255) NOT NULL,
+    job_status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    total_count         INT          NOT NULL DEFAULT 0,
+    registered_at       DATETIME     NOT NULL,
+    success_count       INT          NOT NULL DEFAULT 0,
+    fail_count          INT          NOT NULL DEFAULT 0,
+    start_at            DATETIME,
+    end_at              DATETIME,
+    retry_success_count INT          NOT NULL DEFAULT 0,
+    retry_fail_count    INT          NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
+    INDEX idx_push_clusters_job_status (job_status),
     CONSTRAINT fk_push_clusters_club_event FOREIGN KEY (club_event_id) REFERENCES club_events (event_id)
 );
 
 -- push_cluster_tokens
+-- findAllByPushClusterWithMember
+--   → idx_pct_push_cluster_id (push_cluster_id)
+-- findRecoverableTokens — OR 조건 3개를 각 인덱스로 개별 커버
+--   PENDING      AND request_time   < ?  → idx_pct_status_request_time   (job_status, request_time)
+--   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed_time (job_status, processed_time)
+--   RETRY_PENDING AND retry_after <= ? AND retry_count <= ?
+--                                        → idx_pct_status_retry          (job_status, retry_after, retry_count)
 CREATE TABLE IF NOT EXISTS push_cluster_tokens (
-    id               BIGINT       NOT NULL AUTO_INCREMENT,
-    push_cluster_id  BIGINT       NOT NULL,
-    member_id        BIGINT       NOT NULL,
-    token_value      VARCHAR(255),
-    job_status       VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
-    request_time     DATETIME     NOT NULL,
-    processed_time   DATETIME,
-    retry_count      INT          NOT NULL DEFAULT 0,
-    retry_after      DATETIME,
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    push_cluster_id BIGINT       NOT NULL,
+    member_id       BIGINT       NOT NULL,
+    token_value     VARCHAR(255),
+    job_status      VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    request_time    DATETIME     NOT NULL,
+    processed_time  DATETIME,
+    retry_count     INT          NOT NULL DEFAULT 0,
+    retry_after     DATETIME,
     PRIMARY KEY (id),
+    INDEX idx_pct_push_cluster_id    (push_cluster_id),
+    INDEX idx_pct_status_request     (job_status, request_time),
+    INDEX idx_pct_status_processed   (job_status, processed_time),
+    INDEX idx_pct_status_retry       (job_status, retry_after, retry_count),
     CONSTRAINT fk_push_cluster_tokens_push_cluster FOREIGN KEY (push_cluster_id) REFERENCES push_clusters (id),
     CONSTRAINT fk_push_cluster_tokens_member       FOREIGN KEY (member_id)       REFERENCES members       (id)
 );
 
 -- push_notifications
+-- findByMemberAndNotificationType / findTopicNotificationsByMemberWithTopic
+-- findKeywordNotificationsByMemberWithTopicAndKeyword
+--   → idx_pn_member_type_notified (member_id, notification_type, notified_at)
+--     notification_type = 'TOPIC'/'KEYWORD' 필터 후 notified_at DESC 정렬 커버
+-- countByMemberAndIsReadFalse / updateAllUnreadByMember
+--   → idx_pn_member_isread (member_id, is_read)
+-- findFirstByPushClusterId
+--   → idx_pn_push_cluster_id (push_cluster_id)
 CREATE TABLE IF NOT EXISTS push_notifications (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
     push_cluster_id   BIGINT       NOT NULL,
@@ -189,6 +259,9 @@ CREATE TABLE IF NOT EXISTS push_notifications (
     clicked_at        DATETIME,
     notified_at       DATETIME,
     PRIMARY KEY (id),
+    INDEX idx_pn_member_type_notified (member_id, notification_type, notified_at),
+    INDEX idx_pn_member_isread        (member_id, is_read),
+    INDEX idx_pn_push_cluster_id      (push_cluster_id),
     CONSTRAINT fk_push_notifications_push_cluster FOREIGN KEY (push_cluster_id) REFERENCES push_clusters (id),
     CONSTRAINT fk_push_notifications_topic        FOREIGN KEY (topic_id)        REFERENCES topics        (id),
     CONSTRAINT fk_push_notifications_keyword      FOREIGN KEY (keyword_id)      REFERENCES keywords      (id),
@@ -211,4 +284,4 @@ CREATE TABLE IF NOT EXISTS shedlock (
     locked_at  TIMESTAMP(3) NOT NULL,
     locked_by  VARCHAR(255) NOT NULL,
     PRIMARY KEY (name)
-    );
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -212,10 +212,10 @@ CREATE TABLE IF NOT EXISTS push_clusters (
 -- findAllByPushClusterWithMember
 --   → idx_pct_push_cluster_id (push_cluster_id)
 -- findRecoverableTokens — OR 조건 3개를 각 인덱스로 개별 커버
---   PENDING      AND request_time   < ?  → idx_pct_status_request        (job_status, request_time)
---   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed      (job_status, processed_time)
+--   PENDING      AND request_time   < ?  → idx_pct_status_request   (job_status, request_time)
+--   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed (job_status, processed_time)
 --   RETRY_PENDING AND retry_after <= ? AND retry_count <= ?
---                                        → idx_pct_status_retry          (job_status, retry_after, retry_count)
+--                                        → idx_pct_status_retry     (job_status, retry_after, retry_count)
 CREATE TABLE IF NOT EXISTS push_cluster_tokens (
     id              BIGINT       NOT NULL AUTO_INCREMENT,
     push_cluster_id BIGINT       NOT NULL,


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #72 

## 💡 작업 내용

- ClubEvent 목록조회시 content 필드를 추가하여 Endpoint 스펙을 V1과 완전히 일치시킵니다.
- 누락된 record(Request, Response DTO)의 Swagger 명세를 추가합니다.
- 이때, 미리보기에 대해서 VARCHAR와 TEXT의 비교를 통해 성능개선을 진행합니다.
- Index를 구성하고, 이를 ddl 파일로 정의합니다.

## 📝 추가 설명(선택)

### 1. API 명세 수정 (V1과 일치 및 DTO 문서화)

- [x] ClubEventResponse와 ClubEventWithKeywordResponse의 content 필드 추가 -> Endpoint 스펙 V1과 완전히 일치
- [x] Swagger에 @Schema 애너테이션으로 설명을 추가

### 2. VARCHAR vs TEXT 비교 및 성능개선

- 목록 조회에서 TEXT 컬럼을 SELECT하면 행 수만큼 추가 I/O가 발생하기에, content_preview 같은 VARCHAR 미리보기 컬럼을 분리하면, 목록은 인라인 데이터만, 상세는 전체 본문만 읽는 방식으로의 분리를 진행합니다.
- [x] 코드 구현
- [x] 테스트 진행 및 결과 분석
- [참고 문서 (공지사항 조회 성능 개선)](https://rlagnlfo1004.tistory.com/entry/%EA%B3%B5%EC%A7%80%EC%82%AC%ED%95%AD-%EC%A1%B0%ED%9A%8C-%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0-1%ED%8E%B8-VARCHAR-vs-TEXT)
- 관련 테스트 스크립트를 @docs/test-text-varchar.sql 에 기록하였습니다.

### 3. 인덱스 지정
- [x] 적절한 인덱스 지정
- [x] ddl 파일 정의
  - 쿼리를 분석하여 각 쿼리에 필요한 인덱스를 설계하였습니다.
  - @docs/add-indexes.sql 파일에 위치합니다.
  - 또한, 운영 DB 에 적용을 위해 기존 테이블에 인덱스를 추가할 ALTER 스크립트도 같이 정리하였습니다.


## 📚 참고 자료(선택)

- [공지사항 조회 성능 개선 - 1편 (VARCHAR vs TEXT)](https://rlagnlfo1004.tistory.com/entry/%EA%B3%B5%EC%A7%80%EC%82%AC%ED%95%AD-%EC%A1%B0%ED%9A%8C-%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0-1%ED%8E%B8-VARCHAR-vs-TEXT)

- @docs/test-text-varchar.sql
- @docs/add-indexes.sql