### PR TITLE
[Bug] docker-compose actuator 포트 9090 미노출로 Prometheus   scrape 불가 #74

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       REDIS_PORT: 6379
     ports:
       - "8080:8080"
+      - "9090:9090"
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## 🔗 관련 이슈

>  #74

## 💡 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
  - docker-compose.yml app 서비스에 9090:9090 포트 매핑 추가
  - Spring Boot management.server.port: 9090 설정은 되어 있었으나,
  docker가 해당 포트를 외부로 노출하지 않아 Prometheus scrape 불가
  상태였음
  - 포트 추가 후 모니터링 EC2에서
  172.31.15.189:9090/actuator/prometheus 접근 가능해짐

## 📝 추가 설명(선택)

> 부가적인 내용이 있다면 작성해주세요
  보안 그룹에서 9090 포트는 모니터링 EC2 프라이빗
  IP(172.31.36.166/32)로만 인바운드 제한되어 있어 외부 노출 위험 없음

## 📚 참고 자료(선택)

> 필요한 자료나 사진을 첨부해주세요

