### PR TITLE
[Fix] actuator 전용 SecurityFilterChain 추가로 Prometheus scrape 401 해결 #76

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/config/SecurityConfig.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -54,6 +55,17 @@ public class SecurityConfig implements WebMvcConfigurer {
     };
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/actuator/**")
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         List<String> whitelist = new ArrayList<>(Arrays.asList(AUTH_WHITELIST));
         if (Arrays.asList(environment.getActiveProfiles()).contains("local")) {


### PR DESCRIPTION
## 🔗 관련 이슈

> ex) #이슈번호, #이슈번호
#76 

## 💡 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
 - SecurityConfig에 /actuator/** 전용 @Order(1) SecurityFilterChain 추가
  - management.server.port=9090으로 포트를 분리했음에도 메인 앱의 SecurityFilterChain이 동일
  서블릿 컨텍스트를 통해 9090 포트에도 적용되어 Prometheus scrape 시 401 반환되던 문제 해결
  - actuator 전용 체인이 메인 체인(@Order(2))보다 먼저 평가되어 /actuator/** 요청은 인증 없이 통과

## 📝 추가 설명(선택)

> 부가적인 내용이 있다면 작성해주세요
- 9090 포트는 AWS 보안 그룹에서 모니터링 EC2 프라이빗 IP(172.31.36.166/32)로만 인바운드 제한되어 있어 외부 노출 위험 없음. 로컬에서 curl http://localhost:9090/actuator/prometheus 응답 정상 확인 후 PR 올림

## 📚 참고 자료(선택)

> 필요한 자료나 사진을 첨부해주세요

