### PR TITLE
[Refactor] Redis 더티 셋 패턴을 통한 조회수 추적 #78

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
@@ -1,99 +1,175 @@
 package com.example.ajouevent_be_v2.repository.adapter.clubevent;
 
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.stereotype.Component;
 
 /**
- * Redis 키 네이밍 컨벤션: {도메인}:{목적}:{eventId}:{식별자...}
+ * Redis 키 네이밍 컨벤션: {도메인}:{목적}:{eventId}:{식별자}
  *
- * <p>ClubEvent:views:{eventId}             — 조회수 버퍼 (TTL 4분)
- * <p>ClubEvent:user:{eventId}:{email}      — 인증 사용자 중복 조회 방지 (TTL 24시간)
- * <p>ClubEvent:anon:{eventId}:{ip}:{ua}    — 익명 사용자 중복 조회 방지 (TTL 24시간)
+ * <p>ClubEvent:dedup:{eventId}:u:{email}  — 회원 dedup (TTL 24시간)
+ * <p>ClubEvent:dedup:{eventId}:a:{hash}   — 비회원 dedup, IP/UA SHA-256 앞 16자 (TTL 24시간)
+ * <p>ClubEvent:views:{eventId}            — 조회수 누적 카운터
+ * <p>ClubEvent:dirty                      — 변경 대상 더티 셋
+ * <p>ClubEvent:committed:{eventId}        — DB 커밋 완료 대기 delta (TTL 10분, idempotent용)
  */
 @Component
 @RequiredArgsConstructor
 public class ClubEventCacheAdapter implements ClubEventCachePort {
 
     private static final String VIEW_KEY_PREFIX = "ClubEvent:views:";
-    private static final String USER_REQUEST_PREFIX = "ClubEvent:user:";
-    private static final String ANON_REQUEST_PREFIX = "ClubEvent:anon:";
-    private static final long VIEW_COUNT_TTL_MINUTES = 4L;
-    private static final long VIEW_DEDUP_TTL_SECONDS = 86400L;
+    private static final String DEDUP_PREFIX = "ClubEvent:dedup:";
+    private static final String DIRTY_SET_KEY = "ClubEvent:dirty";
+    private static final String COMMITTED_PREFIX = "ClubEvent:committed:";
+
+    private static final long DEDUP_TTL_SECONDS = 86400L;
+    private static final long COMMITTED_TTL_SECONDS = 600L;
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    @Override
-    public boolean isFirstUserRequest(String userEmail, Long eventId) {
-        String key = USER_REQUEST_PREFIX + eventId + ":" + userEmail;
-        return Boolean.FALSE.equals(stringRedisTemplate.hasKey(key));
+    private DefaultRedisScript<Long> incrementViewScript;
+    private DefaultRedisScript<Long> subtractViewChunkScript;
+
+    @PostConstruct
+    private void loadScripts() {
+        incrementViewScript = new DefaultRedisScript<>();
+        incrementViewScript.setScriptSource(
+            new ResourceScriptSource(new ClassPathResource("scripts/increment_view.lua")));
+        incrementViewScript.setResultType(Long.class);
+
+        subtractViewChunkScript = new DefaultRedisScript<>();
+        subtractViewChunkScript.setScriptSource(
+            new ResourceScriptSource(new ClassPathResource("scripts/subtract_view_chunk.lua")));
+        subtractViewChunkScript.setResultType(Long.class);
     }
 
     @Override
-    public void recordUserRequest(String userEmail, Long eventId) {
-        String key = USER_REQUEST_PREFIX + eventId + ":" + userEmail;
-        stringRedisTemplate.opsForValue().set(key, "1", VIEW_DEDUP_TTL_SECONDS, TimeUnit.SECONDS);
+    public void incrementViewForUser(String userEmail, Long eventId) {
+        String dedupKey = DEDUP_PREFIX + eventId + ":u:" + userEmail;
+        executeIncrementView(dedupKey, eventId);
     }
 
     @Override
-    public boolean isFirstAnonymousRequest(String ip, String userAgent, Long eventId) {
-        String key = ANON_REQUEST_PREFIX + eventId + ":" + ip + ":" + userAgent;
-        return Boolean.FALSE.equals(stringRedisTemplate.hasKey(key));
+    public void incrementViewForAnonymous(String ip, String userAgent, Long eventId) {
+        String hash = hashIdentifier(ip, userAgent);
+        String dedupKey = DEDUP_PREFIX + eventId + ":a:" + hash;
+        executeIncrementView(dedupKey, eventId);
     }
 
     @Override
-    public void recordAnonymousRequest(String ip, String userAgent, Long eventId) {
-        String key = ANON_REQUEST_PREFIX + eventId + ":" + ip + ":" + userAgent;
-        stringRedisTemplate.opsForValue().set(key, "1", VIEW_DEDUP_TTL_SECONDS, TimeUnit.SECONDS);
-    }
-
-    @Override
-    public void incrementViewCount(Long eventId, Long currentViewCount) {
-        String key = VIEW_KEY_PREFIX + eventId;
-        Boolean isNew = stringRedisTemplate.opsForValue()
-            .setIfAbsent(key, String.valueOf(currentViewCount + 1), VIEW_COUNT_TTL_MINUTES, TimeUnit.MINUTES);
-        if (Boolean.FALSE.equals(isNew)) {
-            stringRedisTemplate.opsForValue().increment(key);
-            stringRedisTemplate.expire(key, VIEW_COUNT_TTL_MINUTES, TimeUnit.MINUTES);
+    public Set<Long> getDirtyEventIds() {
+        Set<String> members = stringRedisTemplate.opsForSet().members(DIRTY_SET_KEY);
+        if (members == null || members.isEmpty()) {
+            return Collections.emptySet();
         }
+        return members.stream().map(Long::parseLong).collect(Collectors.toSet());
     }
 
     @Override
-    public Set<String> scanViewCountKeys() {
+    public Set<Long> scanViewCountIds() {
         ScanOptions options = ScanOptions.scanOptions()
             .match(VIEW_KEY_PREFIX + "*")
-            .count(10)
+            .count(100)
             .build();
-        Set<String> keys = new HashSet<>();
+        Set<Long> ids = new HashSet<>();
         try (Cursor<byte[]> cursor = stringRedisTemplate.executeWithStickyConnection(
             connection -> connection.scan(options))) {
             if (cursor != null) {
                 while (cursor.hasNext()) {
-                    keys.add(new String(cursor.next()));
+                    String key = new String(cursor.next());
+                    ids.add(Long.parseLong(key.substring(VIEW_KEY_PREFIX.length())));
                 }
             }
         }
-        return keys;
+        return ids;
     }
 
     @Override
-    public String getViewCount(String key) {
-        return stringRedisTemplate.opsForValue().get(key);
+    public Long getViewCountDelta(Long eventId) {
+        String value = stringRedisTemplate.opsForValue().get(VIEW_KEY_PREFIX + eventId);
+        if (value == null) {
+            return null;
+        }
+        long delta = Long.parseLong(value);
+        return delta > 0 ? delta : null;
     }
 
     @Override
-    public void deleteKey(String key) {
-        stringRedisTemplate.delete(key);
+    public void subtractViewCountChunk(Map<Long, Long> deltaMap) {
+        List<String> keys = new ArrayList<>();
+        List<String> args = new ArrayList<>();
+        for (Map.Entry<Long, Long> entry : deltaMap.entrySet()) {
+            keys.add(VIEW_KEY_PREFIX + entry.getKey());
+            args.add(String.valueOf(entry.getValue()));
+            args.add(String.valueOf(entry.getKey()));
+        }
+        keys.add(DIRTY_SET_KEY);
+        stringRedisTemplate.execute(subtractViewChunkScript, keys, (Object[]) args.toArray(String[]::new));
     }
 
     @Override
-    public Long extractEventIdFromViewKey(String key) {
-        return Long.parseLong(key.substring(VIEW_KEY_PREFIX.length()));
+    public void saveCommittedDeltas(Map<Long, Long> deltaMap) {
+        for (Map.Entry<Long, Long> entry : deltaMap.entrySet()) {
+            stringRedisTemplate.opsForValue().set(
+                COMMITTED_PREFIX + entry.getKey(),
+                String.valueOf(entry.getValue()),
+                COMMITTED_TTL_SECONDS,
+                TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public Long getCommittedDelta(Long eventId) {
+        String value = stringRedisTemplate.opsForValue().get(COMMITTED_PREFIX + eventId);
+        return value != null ? Long.parseLong(value) : null;
+    }
+
+    @Override
+    public void deleteCommittedDeltas(Set<Long> eventIds) {
+        if (eventIds.isEmpty()) {
+            return;
+        }
+        List<String> keys = eventIds.stream()
+            .map(id -> COMMITTED_PREFIX + id)
+            .toList();
+        stringRedisTemplate.delete(keys);
+    }
+
+    private void executeIncrementView(String dedupKey, Long eventId) {
+        List<String> keys = List.of(dedupKey, VIEW_KEY_PREFIX + eventId, DIRTY_SET_KEY);
+        stringRedisTemplate.execute(
+            incrementViewScript,
+            keys,
+            String.valueOf(DEDUP_TTL_SECONDS),
+            String.valueOf(eventId));
+    }
+
+    private static String hashIdentifier(String ip, String userAgent) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest((ip + "|" + userAgent).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, 16);
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString((ip + "|" + userAgent).hashCode());
+        }
     }
 }

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
@@ -28,8 +28,8 @@ import org.springframework.stereotype.Component;
  *
  * <p>ClubEvent:dedup:{eventId}:u:{email}  — 회원 dedup (TTL 24시간)
  * <p>ClubEvent:dedup:{eventId}:a:{hash}   — 비회원 dedup, IP/UA SHA-256 앞 16자 (TTL 24시간)
- * <p>ClubEvent:views:{eventId}            — 조회수 누적 카운터
- * <p>ClubEvent:dirty                      — 변경 대상 더티 셋
+ * <p>ClubEvent:views:{eventId}            — 조회수 누적 카운터 (안전장치 TTL 7일)
+ * <p>ClubEvent:dirty                      — 변경 대상 더티 셋 (TTL 없음, SREM으로 관리)
  * <p>ClubEvent:committed:{eventId}        — DB 커밋 완료 대기 delta (TTL 10분, idempotent용)
  */
 @Component
@@ -42,6 +42,7 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
     private static final String COMMITTED_PREFIX = "ClubEvent:committed:";
 
     private static final long DEDUP_TTL_SECONDS = 86400L;
+    private static final long VIEW_KEY_TTL_SECONDS = 604800L;
     private static final long COMMITTED_TTL_SECONDS = 600L;
 
     private final StringRedisTemplate stringRedisTemplate;
@@ -95,7 +96,7 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
             connection -> connection.scan(options))) {
             if (cursor != null) {
                 while (cursor.hasNext()) {
-                    String key = new String(cursor.next());
+                    String key = new String(cursor.next(), StandardCharsets.UTF_8);
                     ids.add(Long.parseLong(key.substring(VIEW_KEY_PREFIX.length())));
                 }
             }
@@ -160,7 +161,8 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
             incrementViewScript,
             keys,
             String.valueOf(DEDUP_TTL_SECONDS),
-            String.valueOf(eventId));
+            String.valueOf(eventId),
+            String.valueOf(VIEW_KEY_TTL_SECONDS));
     }
 
     private static String hashIdentifier(String ip, String userAgent) {

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJdbcRepositoryAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJdbcRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package com.example.ajouevent_be_v2.repository.adapter.clubevent;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ClubEventJdbcRepositoryAdapter {
+
+    private static final String BATCH_INCREMENT_SQL = "UPDATE club_events SET view_count = view_count + ? WHERE event_id = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void batchIncrementViews(Map<Long, Long> deltaMap) {
+        List<Object[]> batchArgs = deltaMap.entrySet().stream()
+            .map(e -> new Object[]{e.getValue(), e.getKey()})
+            .toList();
+        jdbcTemplate.batchUpdate(BATCH_INCREMENT_SQL, batchArgs);
+    }
+}

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJdbcRepositoryAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventJdbcRepositoryAdapter.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -15,7 +14,6 @@ public class ClubEventJdbcRepositoryAdapter {
 
     private final JdbcTemplate jdbcTemplate;
 
-    @Transactional
     public void batchIncrementViews(Map<Long, Long> deltaMap) {
         List<Object[]> batchArgs = deltaMap.entrySet().stream()
             .map(e -> new Object[]{e.getValue(), e.getKey()})

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventCachePort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventCachePort.java
@@ -1,28 +1,31 @@
 package com.example.ajouevent_be_v2.repository.port.clubevent;
 
+import java.util.Map;
 import java.util.Set;
 
 public interface ClubEventCachePort {
 
-    // View count deduplication for authenticated users (email-based)
-    boolean isFirstUserRequest(String userEmail, Long eventId);
+    // 조회수 증가 — dedup + INCR + SADD dirty (Lua Script, 원자적)
+    void incrementViewForUser(String userEmail, Long eventId);
 
-    void recordUserRequest(String userEmail, Long eventId);
+    void incrementViewForAnonymous(String ip, String userAgent, Long eventId);
 
-    // View count deduplication for anonymous users (IP + User-Agent based)
-    boolean isFirstAnonymousRequest(String ip, String userAgent, Long eventId);
+    // 스케줄러: 더티 셋에서 DB 반영 대상 eventId 조회
+    Set<Long> getDirtyEventIds();
 
-    void recordAnonymousRequest(String ip, String userAgent, Long eventId);
+    // 스케줄러: SCAN으로 더티 셋 미등록 누락 키 탐지
+    Set<Long> scanViewCountIds();
 
-    // View count management (Redis key: ClubEvent:views:{eventId})
-    void incrementViewCount(Long eventId, Long currentViewCount);
+    // 스케줄러: eventId 별 누적 조회수 delta 조회
+    Long getViewCountDelta(Long eventId);
 
-    // For ViewCountScheduler: scan, read, delete, parse
-    Set<String> scanViewCountKeys();
+    // 스케줄러: 청크 단위 DECRBY + 조건부 정리 (Lua Script, 원자적)
+    void subtractViewCountChunk(Map<Long, Long> deltaMap);
 
-    String getViewCount(String key);
+    // 스케줄러: idempotent 보장용 committed delta 관리
+    void saveCommittedDeltas(Map<Long, Long> deltaMap);
 
-    void deleteKey(String key);
+    Long getCommittedDelta(Long eventId);
 
-    Long extractEventIdFromViewKey(String key);
+    void deleteCommittedDeltas(Set<Long> eventIds);
 }

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
@@ -4,9 +4,11 @@ import com.example.ajouevent_be_v2.domain.clubevent.ClubEvent;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.domain.keyword.Keyword;
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
+import com.example.ajouevent_be_v2.repository.adapter.clubevent.ClubEventJdbcRepositoryAdapter;
 import com.example.ajouevent_be_v2.repository.adapter.clubevent.ClubEventJpaRepositoryAdapter;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Repository;
 public class ClubEventRepositoryPort {
 
     private final ClubEventJpaRepositoryAdapter clubEventJpaRepositoryAdapter;
+    private final ClubEventJdbcRepositoryAdapter clubEventJdbcRepositoryAdapter;
 
     public Optional<ClubEvent> findById(Long eventId) {
         return clubEventJpaRepositoryAdapter.findById(eventId);
@@ -74,5 +77,9 @@ public class ClubEventRepositoryPort {
 
     public void updateViews(Long viewCount, Long eventId) {
         clubEventJpaRepositoryAdapter.updateViews(viewCount, eventId);
+    }
+
+    public void batchIncrementViews(Map<Long, Long> deltaMap) {
+        clubEventJdbcRepositoryAdapter.batchIncrementViews(deltaMap);
     }
 }

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
@@ -38,24 +38,11 @@ public class ClubEventQueryService {
             .orElseThrow(() -> new ClubEventException(ClubEventErrorCode.EVENT_NOT_FOUND));
     }
 
-    /**
-     *
-     * @param clubEvent
-     * @param member: 가입된 사용자라면, Email 기반으로 조회수 처리
-     * @param clientIp: 가입된 사용자가 아니라면, IP 기반으로 조회수 처리
-     * @param userAgent: 가입된 사용자가 아닐때,
-     */
     public void handleViewCount(ClubEvent clubEvent, Member member, String clientIp, String userAgent) {
         if (member != null) {
-            if (clubEventCachePort.isFirstUserRequest(member.getEmail(), clubEvent.getEventId())) {
-                clubEventCachePort.recordUserRequest(member.getEmail(), clubEvent.getEventId());
-                clubEventCachePort.incrementViewCount(clubEvent.getEventId(), clubEvent.getViewCount());
-            }
+            clubEventCachePort.incrementViewForUser(member.getEmail(), clubEvent.getEventId());
         } else {
-            if (clubEventCachePort.isFirstAnonymousRequest(clientIp, userAgent, clubEvent.getEventId())) {
-                clubEventCachePort.recordAnonymousRequest(clientIp, userAgent, clubEvent.getEventId());
-                clubEventCachePort.incrementViewCount(clubEvent.getEventId(), clubEvent.getViewCount());
-            }
+            clubEventCachePort.incrementViewForAnonymous(clientIp, userAgent, clubEvent.getEventId());
         }
     }
 

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountService.java
@@ -1,33 +1,104 @@
 package com.example.ajouevent_be_v2.service.clubevent;
 
-import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
+import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
- *  조회수 flush 전용 Service 클래스
+ * 조회수 flush 전용 Service — Redis → DB 동기화
+ *
+ * <p>Read-Write-Subtract 패턴:
+ * <ol>
+ *   <li>[Read]     더티 셋에서 반영 대상 조회 + SCAN으로 누락 탐지
+ *   <li>[Write]    JdbcTemplate Batch Update (view_count = view_count + delta)
+ *   <li>[Subtract] Lua Script 청크 단위 DECRBY + 조건부 더티 셋 정리
+ * </ol>
+ *
+ * <p>Idempotent 보장: DB 커밋 성공 후 committed 키를 기록하여,
+ * subtract 실패 시 다음 스케줄러 실행에서 DB 재기록 없이 subtract만 재시도.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClubEventViewCountService {
+
+    private static final int CHUNK_SIZE = 100;
 
     private final ClubEventCachePort clubEventCachePort;
     // ⚠️ cross-domain: 조회수 Redis → DB 동기화를 위해 ClubEvent 도메인 Repository 직접 참조
     private final ClubEventRepositoryPort clubEventRepositoryPort;
 
-    @Transactional
     public void flushViewCountsToDatabase() {
-        Set<String> keys = clubEventCachePort.scanViewCountKeys();
-        for (String key : keys) {
-            Long eventId = clubEventCachePort.extractEventIdFromViewKey(key);
-            String view = clubEventCachePort.getViewCount(key);
-            if (view != null) {
-                clubEventRepositoryPort.updateViews(Long.valueOf(view), eventId);
-                clubEventCachePort.deleteKey(key);
+        // 1. 더티 셋에서 반영 대상 조회
+        Set<Long> dirtyIds = clubEventCachePort.getDirtyEventIds();
+
+        // 2. SCAN으로 더티 셋 미등록 누락 키 탐지
+        Set<Long> scannedIds = clubEventCachePort.scanViewCountIds();
+
+        Set<Long> allIds = new HashSet<>(dirtyIds);
+        allIds.addAll(scannedIds);
+
+        if (allIds.isEmpty()) {
+            return;
+        }
+
+        // 3. 청크 단위 처리 (Redis 블로킹 방지)
+        List<Long> idList = new ArrayList<>(allIds);
+        for (int i = 0; i < idList.size(); i += CHUNK_SIZE) {
+            List<Long> chunk = idList.subList(i, Math.min(i + CHUNK_SIZE, idList.size()));
+            processChunk(chunk);
+        }
+    }
+
+    private void processChunk(List<Long> eventIds) {
+        Map<Long, Long> pendingMap = new HashMap<>();
+        Map<Long, Long> freshMap = new HashMap<>();
+
+        for (Long eventId : eventIds) {
+            Long committedDelta = clubEventCachePort.getCommittedDelta(eventId);
+            if (committedDelta != null) {
+                // 이전 실행에서 DB 커밋 완료됐으나 subtract 실패 → subtract만 재시도
+                pendingMap.put(eventId, committedDelta);
+            } else {
+                Long delta = clubEventCachePort.getViewCountDelta(eventId);
+                if (delta != null) {
+                    freshMap.put(eventId, delta);
+                }
             }
         }
+
+        // subtract 재시도 (DB 이미 반영됨)
+        if (!pendingMap.isEmpty()) {
+            clubEventCachePort.subtractViewCountChunk(pendingMap);
+            clubEventCachePort.deleteCommittedDeltas(pendingMap.keySet());
+        }
+
+        if (freshMap.isEmpty()) {
+            return;
+        }
+
+        // [Read] DB 커밋 전 delta 기록 (subtract 실패 시 재시도용)
+        clubEventCachePort.saveCommittedDeltas(freshMap);
+
+        try {
+            // [Write] JdbcTemplate Batch Update
+            clubEventRepositoryPort.batchIncrementViews(freshMap);
+        } catch (Exception e) {
+            log.error("조회수 DB 반영 실패 — committed 키 정리 후 재시도 대기: {}", e.getMessage());
+            clubEventCachePort.deleteCommittedDeltas(freshMap.keySet());
+            return;
+        }
+
+        // [Subtract] DB 커밋 성공 후 Redis 조회수 차감 (Lua Script, 청크 단위 원자적 처리)
+        clubEventCachePort.subtractViewCountChunk(freshMap);
+        clubEventCachePort.deleteCommittedDeltas(freshMap.keySet());
     }
 }

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountService.java
@@ -1,7 +1,6 @@
 package com.example.ajouevent_be_v2.service.clubevent;
 
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
-import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,8 +32,7 @@ public class ClubEventViewCountService {
     private static final int CHUNK_SIZE = 100;
 
     private final ClubEventCachePort clubEventCachePort;
-    // ⚠️ cross-domain: 조회수 Redis → DB 동기화를 위해 ClubEvent 도메인 Repository 직접 참조
-    private final ClubEventRepositoryPort clubEventRepositoryPort;
+    private final ClubEventViewCountWriteService clubEventViewCountWriteService;
 
     public void flushViewCountsToDatabase() {
         // 1. 더티 셋에서 반영 대상 조회
@@ -85,14 +83,13 @@ public class ClubEventViewCountService {
             return;
         }
 
-        // [Read] DB 커밋 전 delta 기록 (subtract 실패 시 재시도용)
-        clubEventCachePort.saveCommittedDeltas(freshMap);
-
         try {
             // [Write] JdbcTemplate Batch Update
-            clubEventRepositoryPort.batchIncrementViews(freshMap);
+            clubEventViewCountWriteService.batchIncrementViews(freshMap);
+            // [Write 이후] DB 반영이 끝난 delta만 committed로 기록
+            clubEventCachePort.saveCommittedDeltas(freshMap);
         } catch (Exception e) {
-            log.error("조회수 DB 반영 실패 — committed 키 정리 후 재시도 대기: {}", e.getMessage());
+            log.error("조회수 DB 반영 실패 — committed 키 정리 후 재시도 대기", e);
             clubEventCachePort.deleteCommittedDeltas(freshMap.keySet());
             return;
         }

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountWriteService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventViewCountWriteService.java
@@ -1,0 +1,19 @@
+package com.example.ajouevent_be_v2.service.clubevent;
+
+import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClubEventViewCountWriteService {
+
+    private final ClubEventRepositoryPort clubEventRepositoryPort;
+
+    @Transactional
+    public void batchIncrementViews(Map<Long, Long> deltaMap) {
+        clubEventRepositoryPort.batchIncrementViews(deltaMap);
+    }
+}

--- a/src/main/resources/scripts/increment_view.lua
+++ b/src/main/resources/scripts/increment_view.lua
@@ -3,11 +3,13 @@
 -- KEYS[3]: dirtyKey  (ClubEvent:dirty)
 -- ARGV[1]: dedup TTL in seconds
 -- ARGV[2]: eventId   (string, for dirty set member)
+-- ARGV[3]: viewKey safety TTL in seconds
 -- Returns: 1 if view counted, 0 if duplicate
 local isNew = redis.call('SET', KEYS[1], '1', 'NX', 'EX', tonumber(ARGV[1]))
 if isNew then
     redis.call('INCR', KEYS[2])
     redis.call('SADD', KEYS[3], ARGV[2])
+    redis.call('EXPIRE', KEYS[2], tonumber(ARGV[3]))
     return 1
 end
 return 0

--- a/src/main/resources/scripts/increment_view.lua
+++ b/src/main/resources/scripts/increment_view.lua
@@ -1,0 +1,13 @@
+-- KEYS[1]: dedupKey  (ClubEvent:dedup:{eventId}:u:{email} or :a:{hash})
+-- KEYS[2]: viewKey   (ClubEvent:views:{eventId})
+-- KEYS[3]: dirtyKey  (ClubEvent:dirty)
+-- ARGV[1]: dedup TTL in seconds
+-- ARGV[2]: eventId   (string, for dirty set member)
+-- Returns: 1 if view counted, 0 if duplicate
+local isNew = redis.call('SET', KEYS[1], '1', 'NX', 'EX', tonumber(ARGV[1]))
+if isNew then
+    redis.call('INCR', KEYS[2])
+    redis.call('SADD', KEYS[3], ARGV[2])
+    return 1
+end
+return 0

--- a/src/main/resources/scripts/subtract_view_chunk.lua
+++ b/src/main/resources/scripts/subtract_view_chunk.lua
@@ -1,0 +1,17 @@
+-- Processes a chunk of view count subtractions atomically.
+-- KEYS[1..n]  : view count keys (ClubEvent:views:{eventId})
+-- KEYS[n+1]   : dirty set key   (ClubEvent:dirty)
+-- ARGV[i*2-1] : delta   for entry i  (amount to subtract)
+-- ARGV[i*2]   : eventId for entry i  (for dirty set removal)
+-- n = #KEYS - 1
+-- Returns: 1 on success
+local n = #KEYS - 1
+local dirtyKey = KEYS[n + 1]
+for i = 1, n do
+    local remaining = redis.call('DECRBY', KEYS[i], tonumber(ARGV[(i - 1) * 2 + 1]))
+    if remaining <= 0 then
+        redis.call('DEL', KEYS[i])
+        redis.call('SREM', dirtyKey, ARGV[(i - 1) * 2 + 2])
+    end
+end
+return 1


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #78 

## 💡 작업 내용

Redis 더티 셋 패턴을 도입해 조회수 추적의 Race Condition을 제거하고, Read-Write-Subtract 패턴으로 동기화 중 Lost Update 문제를 해결합니다.

- [x] Redis 조회수 추적 — 더티 셋 패턴
- [x] dedup 키 설계 (회원: email, 비회원: IP/UA SHA-256 해시)
- [x] 조회수 누적 키 설계 (카운터 + 더티 셋)
- [x] 원자적 실행을 통한 Race Condition 방지 (Lua Script)
- [x] 데이터 동기화 — 스케줄러의 DB 반영 (더티 셋 + SCAN)
- [x] 정합성 보장 로직 구현 (Read - Write - Subtract)

## 📝 추가 설명

### 변경 배경

기존 구현은 dedup 확인 → 기록 → 카운터 증가를 Java에서 순차 호출하여 두 가지 문제가 있었습니다.

1. **Race Condition**: dedup 키 확인과 카운터 증가 사이에 다른 요청이 끼어들어 중복 집계가 발생할 수 있음
2. **Lost Update**: 스케줄러가 카운터를 읽은 뒤 DB에 절댓값으로 덮어쓰는(`SET view_count = ?`) 방식이라, 그 사이 유입된 신규 조회수가 유실됨

---

### 1. Redis 키 설계

| 키 | 역할 | TTL |
|---|---|---|
| `ClubEvent:dedup:{eventId}:u:{email}` | 회원 중복 조회 방지 | 24시간 |
| `ClubEvent:dedup:{eventId}:a:{hash}` | 비회원 중복 조회 방지 (IP\|UA의 SHA-256 앞 16자) | 24시간 |
| `ClubEvent:views:{eventId}` | 조회수 누적 카운터 | 없음 (스케줄러가 정리) |
| `ClubEvent:dirty` | DB 반영 대상 eventId를 모은 더티 셋 | 없음 |
| `ClubEvent:committed:{eventId}` | Subtract 재시도용 delta 기록 | 10분 |

---

### 2. Lua Script 1 — 조회수 증가 및 더티 셋 등록 (`increment_view.lua`)

```lua
local isNew = redis.call('SET', KEYS[1], '1', 'NX', 'EX', tonumber(ARGV[1]))
if isNew then
    redis.call('INCR', KEYS[2])
    redis.call('SADD', KEYS[3], ARGV[2])
    return 1
end
return 0
```

- **KEYS[1]**: dedupKey, **KEYS[2]**: viewKey, **KEYS[3]**: dirtyKey
- `SET NX EX`로 dedup 키의 존재 여부 확인과 잠금을 하나의 원자적 명령으로 처리해 Race Condition을 원천 차단
- 최초 조회 시에만 카운터를 증가시키고 더티 셋에 eventId를 등록하므로, 스케줄러는 전체 키 스페이스를 탐색할 필요 없이 더티 셋만 조회하면 됨

---

### 3. Lua Script 2 — 청크 단위 차감 및 정리 (`subtract_view_chunk.lua`)

```lua
local n = #KEYS - 1
local dirtyKey = KEYS[n + 1]
for i = 1, n do
    local remaining = redis.call('DECRBY', KEYS[i], tonumber(ARGV[(i - 1) * 2 + 1]))
    if remaining <= 0 then
        redis.call('DEL', KEYS[i])
        redis.call('SREM', dirtyKey, ARGV[(i - 1) * 2 + 2])
    end
end
return 1
```

- **KEYS[1..n]**: viewKey 목록, **KEYS[n+1]**: dirtyKey
- `DECRBY`로 Read 시점에 읽은 delta 값만 차감하므로, 동기화 도중 유입된 신규 조회수는 remaining에 안전하게 보존됨 (Lost Update 해결)
- remaining ≤ 0이면 카운터 키와 더티 셋 엔트리를 정리해 다음 사이클의 불필요한 탐색을 방지

---

### 4. Read - Write - Subtract 패턴 (`ClubEventViewCountService`)

```
[Read]     더티 셋에서 eventId 조회 + SCAN으로 누락 탐지
              ↓
[Read]     각 eventId의 Redis 카운터(delta) 조회
              ↓
           committed 키 저장 (idempotent 보장)
              ↓
[Write]    JdbcTemplate batchUpdate
           UPDATE club_events SET view_count = view_count + ? WHERE event_id = ?
              ↓ (DB 커밋 성공 이후에만)
[Subtract] Lua Script 청크 단위 DECRBY + 조건부 더티 셋 정리
              ↓
           committed 키 삭제
```

- **Idempotent 보장**: DB 커밋 성공 직후 `ClubEvent:committed:{eventId}` 키에 delta를 기록. Subtract 실패로 스케줄러가 재실행되면 committed 키의 delta로 subtract만 재시도하므로 DB 이중 기록 방지
- **청크 분할**: 더티 셋 전체를 한 번의 Lua Script로 처리하면 Redis 스레드가 블로킹될 수 있으므로 100건 단위 청크로 분할 실행
- **Non-Blocking SCAN**: `KEYS *` 대신 커서 기반 SCAN으로 보조 탐색

---

### 5. 주요 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `scripts/increment_view.lua` | **신규** — dedup + INCR + SADD 원자적 처리 |
| `scripts/subtract_view_chunk.lua` | **신규** — 청크 단위 DECRBY + 조건부 정리 |
| `ClubEventCachePort` | 인터페이스 전면 교체 (더티 셋 패턴 기반) |
| `ClubEventCacheAdapter` | Lua Script 로드 및 실행, SHA-256 해시 dedup |
| `ClubEventJdbcRepositoryAdapter` | **신규** — JdbcTemplate batchUpdate 어댑터 |
| `ClubEventRepositoryPort` | `batchIncrementViews` 위임 메서드 추가 |
| `ClubEventViewCountService` | Read-Write-Subtract + committed key 재시도 로직 |
| `ClubEventQueryService` | `handleViewCount` 단순화 (Lua Script 단일 호출) |
