### PR TITLE
[Feat] 공지 목록 및 인기글 Redis 캐시 적용 #83

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,12 @@ jobs:
             echo "image_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.app_changed == 'true'
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Log in to Docker Hub
         if: steps.changes.outputs.app_changed == 'true'
         uses: docker/login-action@v3
@@ -51,6 +57,8 @@ jobs:
         with:
           context: .
           push: true
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/ajouevent-be:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/ajouevent-be:buildcache,mode=max
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:latest
             ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:${{ github.sha }}
@@ -76,18 +84,20 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           port: 20000
           key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
           envs: APP_CHANGED,APP_IMAGE,APP_LATEST_IMAGE
           script: |
             cd ~/ajouevent
             if [ "$APP_CHANGED" = "true" ]; then
               export DOCKER_IMAGE="$APP_IMAGE"
-              docker compose pull app
+              docker pull "$DOCKER_IMAGE"
             else
               export DOCKER_IMAGE="$(docker inspect ajouevent-app --format '{{.Config.Image}}' 2>/dev/null || true)"
               if [ -z "$DOCKER_IMAGE" ]; then
                 export DOCKER_IMAGE="$APP_LATEST_IMAGE"
+                docker pull "$DOCKER_IMAGE"
               fi
             fi
 
-            docker compose up -d --pull missing
+            docker compose up -d --pull never
             docker image prune -f

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
@@ -1,21 +1,32 @@
 package com.example.ajouevent_be_v2.repository.adapter.clubevent;
 
+import com.example.ajouevent_be_v2.common.dto.SliceResult;
+import com.example.ajouevent_be_v2.domain.clubevent.EventBanner;
+import com.example.ajouevent_be_v2.domain.clubevent.Type;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -40,12 +51,19 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
     private static final String DEDUP_PREFIX = "ClubEvent:dedup:";
     private static final String DIRTY_SET_KEY = "ClubEvent:dirty";
     private static final String COMMITTED_PREFIX = "ClubEvent:committed:";
+    private static final String TYPE_EVENTS_PREFIX = "ClubEvent:type-events:";
+    private static final String POPULAR_EVENTS_KEY = "ClubEvent:popular-events";
+    private static final String BANNERS_KEY = "ClubEvent:banners";
 
     private static final long DEDUP_TTL_SECONDS = 86400L;
     private static final long VIEW_KEY_TTL_SECONDS = 604800L;
     private static final long COMMITTED_TTL_SECONDS = 600L;
+    private static final Duration TYPE_EVENTS_TTL = Duration.ofHours(6);
+    private static final Duration POPULAR_EVENTS_TTL = Duration.ofHours(1);
+    private static final Duration BANNERS_TTL = Duration.ofHours(24);
 
     private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
 
     private DefaultRedisScript<Long> incrementViewScript;
     private DefaultRedisScript<Long> subtractViewChunkScript;
@@ -61,6 +79,49 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
         subtractViewChunkScript.setScriptSource(
             new ResourceScriptSource(new ClassPathResource("scripts/subtract_view_chunk.lua")));
         subtractViewChunkScript.setResultType(Long.class);
+    }
+
+    @Override
+    public Optional<SliceResult<ClubEventSummaryResult>> getTypeEvents(Type type, String keyword, Pageable pageable) {
+        return getJson(
+            buildTypeEventsKey(type, keyword, pageable),
+            new TypeReference<SliceResult<ClubEventSummaryResult>>() {});
+    }
+
+    @Override
+    public void saveTypeEvents(
+            Type type, String keyword, Pageable pageable, SliceResult<ClubEventSummaryResult> events) {
+        saveJson(buildTypeEventsKey(type, keyword, pageable), events, TYPE_EVENTS_TTL);
+    }
+
+    @Override
+    public void evictTypeEvents(Type type) {
+        deleteByPattern(TYPE_EVENTS_PREFIX + type.name() + ":*");
+    }
+
+    @Override
+    public Optional<List<ClubEventSummaryResult>> getPopularEvents() {
+        return getJson(POPULAR_EVENTS_KEY, new TypeReference<List<ClubEventSummaryResult>>() {});
+    }
+
+    @Override
+    public void savePopularEvents(List<ClubEventSummaryResult> events) {
+        saveJson(POPULAR_EVENTS_KEY, events, POPULAR_EVENTS_TTL);
+    }
+
+    @Override
+    public void evictPopularEvents() {
+        stringRedisTemplate.delete(POPULAR_EVENTS_KEY);
+    }
+
+    @Override
+    public Optional<List<EventBanner>> getBanners() {
+        return getJson(BANNERS_KEY, new TypeReference<List<EventBanner>>() {});
+    }
+
+    @Override
+    public void saveBanners(List<EventBanner> banners) {
+        saveJson(BANNERS_KEY, banners, BANNERS_TTL);
     }
 
     @Override
@@ -153,6 +214,71 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
             .map(id -> COMMITTED_PREFIX + id)
             .toList();
         stringRedisTemplate.delete(keys);
+    }
+
+    private <T> Optional<T> getJson(String key, TypeReference<T> typeReference) {
+        String json = stringRedisTemplate.opsForValue().get(key);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, typeReference));
+        } catch (JsonProcessingException e) {
+            stringRedisTemplate.delete(key);
+            return Optional.empty();
+        }
+    }
+
+    private void saveJson(String key, Object value, Duration ttl) {
+        try {
+            stringRedisTemplate.opsForValue().set(
+                key,
+                objectMapper.writeValueAsString(value),
+                ttl);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("ClubEvent cache serialization failed", e);
+        }
+    }
+
+    private void deleteByPattern(String pattern) {
+        ScanOptions options = ScanOptions.scanOptions()
+            .match(pattern)
+            .count(100)
+            .build();
+        List<String> keys = new ArrayList<>();
+        try (Cursor<byte[]> cursor = stringRedisTemplate.executeWithStickyConnection(
+            connection -> connection.scan(options))) {
+            if (cursor != null) {
+                while (cursor.hasNext()) {
+                    keys.add(new String(cursor.next(), StandardCharsets.UTF_8));
+                }
+            }
+        }
+        if (!keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+        }
+    }
+
+    private String buildTypeEventsKey(Type type, String keyword, Pageable pageable) {
+        return TYPE_EVENTS_PREFIX
+            + type.name()
+            + ":page:" + pageable.getPageNumber()
+            + ":size:" + pageable.getPageSize()
+            + ":sort:" + normalizeSort(pageable.getSort())
+            + ":keyword:" + normalizeKeyword(keyword);
+    }
+
+    private String normalizeSort(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return "unsorted";
+        }
+        return sort.stream()
+            .map(order -> order.getProperty() + "-" + order.getDirection().name())
+            .collect(Collectors.joining(","));
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return keyword == null ? "" : keyword.trim();
     }
 
     private void executeIncrementView(String dedupKey, Long eventId) {

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventCachePort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventCachePort.java
@@ -1,9 +1,32 @@
 package com.example.ajouevent_be_v2.repository.port.clubevent;
 
+import com.example.ajouevent_be_v2.common.dto.SliceResult;
+import com.example.ajouevent_be_v2.domain.clubevent.EventBanner;
+import com.example.ajouevent_be_v2.domain.clubevent.Type;
+import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
 
 public interface ClubEventCachePort {
+
+    Optional<SliceResult<ClubEventSummaryResult>> getTypeEvents(Type type, String keyword, Pageable pageable);
+
+    void saveTypeEvents(Type type, String keyword, Pageable pageable, SliceResult<ClubEventSummaryResult> events);
+
+    void evictTypeEvents(Type type);
+
+    Optional<List<ClubEventSummaryResult>> getPopularEvents();
+
+    void savePopularEvents(List<ClubEventSummaryResult> events);
+
+    void evictPopularEvents();
+
+    Optional<List<EventBanner>> getBanners();
+
+    void saveBanners(List<EventBanner> banners);
 
     // 조회수 증가 — dedup + INCR + SADD dirty (Lua Script, 원자적)
     void incrementViewForUser(String userEmail, Long eventId);

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/clubevent/ClubEventRepositoryPort.java
@@ -27,6 +27,10 @@ public class ClubEventRepositoryPort {
         return clubEventJpaRepositoryAdapter.findById(eventId);
     }
 
+    public List<ClubEvent> findAllByIds(List<Long> eventIds) {
+        return clubEventJpaRepositoryAdapter.findAllById(eventIds);
+    }
+
     public ClubEvent save(ClubEvent clubEvent) {
         return clubEventJpaRepositoryAdapter.save(clubEvent);
     }

--- a/src/main/java/com/example/ajouevent_be_v2/scheduler/PopularEventCacheScheduler.java
+++ b/src/main/java/com/example/ajouevent_be_v2/scheduler/PopularEventCacheScheduler.java
@@ -1,0 +1,18 @@
+package com.example.ajouevent_be_v2.scheduler;
+
+import com.example.ajouevent_be_v2.service.clubevent.ClubEventQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopularEventCacheScheduler {
+
+    private final ClubEventQueryService clubEventQueryService;
+
+    @Scheduled(cron = "0 0 0/1 * * *")
+    public void refreshPopularEvents() {
+        clubEventQueryService.refreshPopularEventsCache();
+    }
+}

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventCommandService.java
@@ -7,6 +7,7 @@ import com.example.ajouevent_be_v2.domain.clubevent.ClubEventImage;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventCommand;
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
+import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventRepositoryPort;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ public class ClubEventCommandService {
     private static final int CONTENT_PREVIEW_LENGTH = 200;
 
     private final ClubEventRepositoryPort clubEventRepositoryPort;
+    private final ClubEventCachePort clubEventCachePort;
 
     public void isDuplicateNotice(String englishTopic, String title, String url) {
         Type type = parseType(englishTopic);
@@ -71,6 +73,8 @@ public class ClubEventCommandService {
         clubEvent.getClubEventImageList().addAll(images);
 
         ClubEvent saved = clubEventRepositoryPort.save(clubEvent);
+        clubEventCachePort.evictTypeEvents(type);
+        clubEventCachePort.evictPopularEvents();
         log.info("공지사항 저장 완료 - eventId: {}, type: {}", saved.getEventId(), type);
         return saved;
     }

--- a/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/clubevent/ClubEventQueryService.java
@@ -19,6 +19,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -48,16 +50,73 @@ public class ClubEventQueryService {
 
     public SliceResult<ClubEventSummaryResult> getEventsByType(Type type, String keyword, Pageable pageable) {
         String searchKeyword = keyword != null ? keyword : "";
-        Slice<ClubEventSummaryResult> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
-            type, searchKeyword, pageable);
-        return SliceResult.from(slice, pageable);
+        return clubEventCachePort.getTypeEvents(type, searchKeyword, pageable)
+            .map(this::refreshCounts)
+            .orElseGet(() -> {
+                Slice<ClubEventSummaryResult> slice = clubEventRepositoryPort.findByTypeAndTitleContaining(
+                    type, searchKeyword, pageable);
+                SliceResult<ClubEventSummaryResult> result = SliceResult.from(slice, pageable);
+                clubEventCachePort.saveTypeEvents(type, searchKeyword, pageable, result);
+                return result;
+            });
+    }
+
+    public void refreshPopularEventsCache() {
+        clubEventCachePort.savePopularEvents(findPopularEventsFromRepository());
     }
 
     public List<ClubEventSummaryResult> getPopularEvents() {
+        return clubEventCachePort.getPopularEvents()
+            .map(this::refreshCounts)
+            .orElseGet(() -> {
+                List<ClubEventSummaryResult> events = findPopularEventsFromRepository();
+                clubEventCachePort.savePopularEvents(events);
+                return events;
+            });
+    }
+
+    private List<ClubEventSummaryResult> findPopularEventsFromRepository() {
         LocalDate now = LocalDate.now();
         LocalDateTime start = now.with(DayOfWeek.MONDAY).atStartOfDay();
         LocalDateTime end = now.with(DayOfWeek.SUNDAY).atTime(LocalTime.MAX);
         return clubEventRepositoryPort.findTop10ByCreatedAtBetween(start, end);
+    }
+
+    private SliceResult<ClubEventSummaryResult> refreshCounts(SliceResult<ClubEventSummaryResult> cached) {
+        return new SliceResult<>(
+            refreshCounts(cached.result()),
+            cached.hasPrevious(),
+            cached.hasNext(),
+            cached.currentPage(),
+            cached.sort());
+    }
+
+    private List<ClubEventSummaryResult> refreshCounts(List<ClubEventSummaryResult> cached) {
+        List<Long> eventIds = cached.stream()
+            .map(ClubEventSummaryResult::eventId)
+            .toList();
+        Map<Long, ClubEvent> events = clubEventRepositoryPort.findAllByIds(eventIds).stream()
+            .collect(Collectors.toMap(ClubEvent::getEventId, Function.identity()));
+        return cached.stream()
+            .map(event -> refreshCounts(event, events.get(event.eventId())))
+            .toList();
+    }
+
+    private ClubEventSummaryResult refreshCounts(ClubEventSummaryResult cached, ClubEvent event) {
+        if (event == null) {
+            return cached;
+        }
+        return new ClubEventSummaryResult(
+            cached.eventId(),
+            cached.title(),
+            cached.contentPreview(),
+            cached.writer(),
+            cached.createdAt(),
+            event.getLikesCount(),
+            event.getViewCount(),
+            cached.subject(),
+            cached.type(),
+            cached.url());
     }
 
     public SliceResult<ClubEventSummaryResult> getEventsByTypes(List<Type> types, String keyword, Pageable pageable) {
@@ -91,7 +150,12 @@ public class ClubEventQueryService {
     }
 
     public List<EventBanner> getBanners() {
-        return eventBannerRepositoryPort.findAllOrderByBannerOrder();
+        return clubEventCachePort.getBanners()
+            .orElseGet(() -> {
+                List<EventBanner> banners = eventBannerRepositoryPort.findAllOrderByBannerOrder();
+                clubEventCachePort.saveBanners(banners);
+                return banners;
+            });
     }
 
     public SliceResult<ClubEventSummaryResult> getEventsByTypeAndKeywords(Type type, List<Keyword> keywords, Pageable pageable) {

--- a/src/main/java/com/example/ajouevent_be_v2/service/webhook/FcmPushResultService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/webhook/FcmPushResultService.java
@@ -15,6 +15,7 @@ import com.example.ajouevent_be_v2.repository.port.token.TokenRepositoryPort;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.SendResponse;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class FcmPushResultService {
     private final TokenRepositoryPort tokenRepositoryPort;
     private final DiscordMessageService discordMessageService;
     private final PushProperties pushProperties;
+    private final MeterRegistry meterRegistry;
 
     @Transactional
     public void markAsInProgressAndSave(PushCluster pushCluster) {
@@ -68,6 +70,8 @@ public class FcmPushResultService {
         }
 
         pushClusterRepositoryPort.incrementCountsAndUpdateStatus(pushClusterId, successCount, failCount);
+        meterRegistry.counter("fcm.messages.dispatched", "result", "success").increment(successCount);
+        meterRegistry.counter("fcm.messages.dispatched", "result", "fail").increment(failCount);
         log.info("푸시 완료 - PushClusterID: {} 성공: {} 실패: {}", pushClusterId, successCount, failCount);
     }
 
@@ -99,6 +103,8 @@ public class FcmPushResultService {
         }
 
         pushClusterRepositoryPort.incrementRetryCounts(pushClusterId, successCount, failCount);
+        meterRegistry.counter("fcm.messages.dispatched", "result", "success").increment(successCount);
+        meterRegistry.counter("fcm.messages.dispatched", "result", "fail").increment(failCount);
         log.info("재시도 완료 - PushClusterID: {} 성공: {} 실패: {}", pushClusterId, successCount, failCount);
     }
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,6 +14,17 @@ spring:
 ajou:
   swagger:
     server-url: http://localhost:8080
+  fcm:
+    executor:
+      callback:
+        core-pool-size: 8
+        max-pool-size: 32
+        queue-capacity: 500
+        await-termination-seconds: 30
+      default-pool:
+        core-pool-size: 32
+        max-pool-size: 128
+        queue-capacity: 50000
 
 jwt:
   cookie-secure: false

--- a/src/main/resources/config/fcm.yaml
+++ b/src/main/resources/config/fcm.yaml
@@ -6,12 +6,12 @@ ajou:
     default-click-action-url: https://www.ajouevent.com
     executor:
       callback:
-        core-pool-size: 4
-        max-pool-size: 16
-        queue-capacity: 100
+        core-pool-size: 8
+        max-pool-size: 32
+        queue-capacity: 500
         await-termination-seconds: 30
       default-pool:
-        core-pool-size: 4
-        max-pool-size: 16
-        queue-capacity: 100
+        core-pool-size: 32
+        max-pool-size: 128
+        queue-capacity: 50000
         await-termination-seconds: 30


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #83

## 💡 작업 내용

공지 조회 경로의 반복 DB 조회 부하를 줄이기 위해 타입별 공지 목록, 인기 게시글, 배너 조회에 Redis 기반 캐시를 적용합니다.

이번 PR의 핵심은 단순히 Redis에 조회 결과를 저장하는 것이 아니라, 조회 대상별 데이터 특성에 맞춰 캐싱 전략을 다르게 가져가는 것입니다.

- [x] 타입별 공지 목록 조회 캐시 적용
- [x] 인기 게시글 조회 캐시 적용
- [x] 배너 조회 캐시 적용
- [x] 새 공지 저장 시 관련 캐시 무효화
- [x] 인기 게시글 캐시 1시간 주기 warm-up 스케줄러 추가
- [x] 캐시 hit 시에도 viewCount / likesCount 최신값 보정
- [x] 구독 공지 목록은 사용자별 구독 조합과 개인화 이슈로 캐시 대상에서 제외
- [x] FCM 부하테스트용 executor 설정 및 발송 결과 메트릭 반영

## 📝 추가 설명

### 변경 배경

V1에서는 타입별 공지 목록, 인기 게시글, 배너에 Redis 캐시를 사용하고 있었습니다. V2에서도 공지 목록 첫 페이지, 인기 게시글, 배너는 반복 조회 가능성이 높은 API입니다.

특히 타입별 공지 목록은 다음 특징을 가집니다.

1. 대부분의 사용자에게 같은 결과를 반환함
2. 첫 페이지 조회 빈도가 높음
3. 새 공지가 들어올 때 최신순 페이지네이션 결과가 바뀜
4. 사용자별 개인화 값인 star는 목록 데이터와 분리 가능함

따라서 공통 조회 결과는 Redis에 캐시하고, 사용자별 값은 기존 응답 조립 단계에서 별도로 반영하는 방식으로 설계했습니다.

---

### 1. 타입별 공지 목록 캐시

#### 적용 로직

- `ClubEventQueryService.getEventsByType(Type type, String keyword, Pageable pageable)`
- API 흐름: `/api/event/{type}`
- 캐시 데이터: `SliceResult<ClubEventSummaryResult>`

#### 캐시 키 설계

타입별 공지 목록은 같은 type이라도 page, size, sort, keyword에 따라 결과가 달라집니다. 그래서 캐시 키에 조회 결과를 바꾸는 조건을 모두 포함했습니다.

| 구성 요소 | 이유 |
|---|---|
| type | 소프트웨어학과, 장학, 기숙사 등 카테고리별 결과 분리 |
| page | 페이지 번호별 결과 분리 |
| size | 페이지 크기가 다르면 결과 개수가 달라짐 |
| sort | 정렬 기준이 다르면 순서가 달라짐 |
| keyword | 검색어가 있으면 결과 집합이 달라짐 |

예시:

```text
ClubEvent:type-events:SOFTWARE:page:0:size:10:sort:createdAt-DESC:keyword:
```

#### 사용한 캐싱 전략: Cache Aside + 선택적 Eviction

```text
1. Redis에서 타입별 목록 캐시 조회
2. cache hit이면 캐시 데이터 반환
3. cache miss이면 DB 조회
4. 조회 결과를 Redis에 저장
5. 새 공지 저장 시 해당 타입 캐시만 SCAN 기반으로 삭제
```

#### 왜 Cache Aside를 사용했는가

타입별 공지 목록은 읽기 요청이 많고, 쓰기 이벤트는 새 공지 저장 시점으로 명확합니다. 따라서 조회 시점에 캐시를 확인하고, 없으면 DB에서 읽어 캐시에 채우는 Cache Aside 전략이 적합합니다.

Write Through 방식은 공지 저장 시점에 모든 페이지네이션 결과를 미리 계산해야 하므로 적합하지 않습니다. 새 공지 하나가 들어오면 0페이지뿐 아니라 뒤 페이지의 경계도 바뀔 수 있기 때문입니다.

따라서 새 공지 저장 시에는 캐시를 직접 갱신하지 않고, 해당 타입 캐시를 무효화한 뒤 다음 조회에서 다시 채우는 방식으로 처리했습니다.

#### 무효화 전략

새 공지가 저장되면 해당 타입의 최신순 목록이 바뀝니다.

예를 들어 `SOFTWARE` 타입 공지가 새로 저장되면:

```text
ClubEvent:type-events:SOFTWARE:* 삭제
```

전체 캐시를 지우지 않고 해당 타입 캐시만 삭제합니다. 장학 공지가 들어왔는데 기숙사 공지 캐시까지 삭제할 필요는 없기 때문입니다.

또한 Redis 운영 환경에서 `KEYS` 명령은 블로킹 위험이 있으므로, `SCAN` 기반 패턴 삭제를 사용했습니다.

---

### 2. 인기 게시글 캐시

#### 적용 로직

- `ClubEventQueryService.getPopularEvents()`
- API 흐름: `/api/event/popular`
- 캐시 데이터: 이번 주 생성 게시글 중 `viewCount` 기준 Top 10 `ClubEventSummaryResult` 목록

#### 사용한 캐싱 전략: Cache Aside + Scheduled Warm-up

인기 게시글은 홈 화면에서 반복 조회될 가능성이 높고, 결과 크기가 Top 10으로 작습니다. 그래서 Cache Aside를 기본으로 사용하되, 1시간마다 스케줄러가 캐시를 미리 갱신하도록 했습니다.

```text
1. Redis에서 인기글 캐시 조회
2. cache hit이면 캐시 데이터 반환
3. cache miss이면 DB에서 이번 주 Top 10 조회 후 Redis 저장
4. 매 1시간마다 스케줄러가 인기글 캐시 warm-up
5. 새 공지 저장 시 인기글 캐시 evict
```

#### 왜 Scheduled Warm-up을 같이 사용했는가

인기글은 홈 화면에서 자주 접근하는 데이터입니다. 단순 Cache Aside만 사용하면 캐시 만료 직후 첫 사용자가 DB 조회 비용을 부담합니다.

인기글은 데이터 크기가 작고 계산 기준도 명확하므로, 스케줄러로 주기적으로 미리 채워두는 것이 적합합니다. 이 방식은 사용자가 cache miss를 맞을 가능성을 줄이고, 홈 화면 응답 안정성을 높입니다.

#### TTL과 무효화

| 항목 | 값 |
|---|---|
| TTL | 1시간 |
| warm-up 주기 | 1시간 |
| evict 트리거 | 새 공지 저장 시 |

인기글은 조회수 기반 순위이기 때문에 너무 긴 TTL은 적합하지 않습니다. V1과 동일하게 1시간 주기로 갱신하는 방식으로 가져갔습니다.

---

### 3. 배너 캐시

#### 적용 로직

- `ClubEventQueryService.getBanners()`
- API 흐름: `/api/event/banner`
- 캐시 데이터: 배너 목록

#### 사용한 캐싱 전략: Cache Aside + TTL 자연 만료

배너는 변경 빈도가 낮고 조회 빈도는 높은 데이터입니다. 따라서 별도 복잡한 무효화보다 TTL 기반 자연 만료를 사용했습니다.

```text
1. Redis에서 배너 캐시 조회
2. cache hit이면 반환
3. cache miss이면 DB 조회 후 Redis 저장
4. 24시간 TTL로 자연 만료
```

#### 왜 TTL 자연 만료를 사용했는가

현재 V2에서는 배너 등록/삭제 API가 핵심 플로우로 열려 있지 않고, 배너는 공지 목록처럼 새 데이터가 자주 들어와 결과가 바뀌는 구조가 아닙니다.

따라서 이번 범위에서는 24시간 TTL로 자연 만료되도록 두었습니다. 향후 관리자 배너 수정 기능이 활성화되면 저장/삭제 시점에 배너 캐시 evict를 추가하면 됩니다.

---

### 4. 캐시 데이터와 개인화 데이터 분리

캐시에 최종 응답 DTO를 그대로 저장하지 않았습니다.

이유는 `star` 값이 사용자별로 달라지기 때문입니다. 같은 공지라도 A 사용자는 찜했고, B 사용자는 찜하지 않았을 수 있습니다.

따라서 캐시에는 사용자 공통 데이터인 `ClubEventSummaryResult`만 저장하고, 응답 반환 직전에 기존 Orchestrator 흐름에서 이미지와 star 여부를 조립합니다.

```text
캐시 저장 대상
- eventId
- title
- contentPreview
- writer
- createdAt
- likesCount
- viewCount
- subject
- type
- url

요청 시점 조립 대상
- imgUrl
- star
```

이렇게 하면 캐시 효율은 유지하면서 사용자별 개인화 정합성을 지킬 수 있습니다.

---

### 5. cache hit 시 count 보정

목록 자체는 캐시하더라도 `viewCount`, `likesCount`는 변할 수 있습니다.

특히 아주이벤트는 조회수를 Redis에 먼저 누적하고 스케줄러가 DB에 flush하는 구조입니다. 캐시된 목록을 TTL 동안 그대로 반환하면 카운트가 너무 오래 낡아 보일 수 있습니다.

그래서 타입별 공지 목록과 인기글은 cache hit 시에도 eventId 목록으로 DB를 다시 조회해 `viewCount`, `likesCount`를 보정합니다.

```text
cache hit
  -> 캐시된 목록 구조 사용
  -> eventId 목록으로 DB 조회
  -> likesCount / viewCount만 최신 DB 값으로 교체
  -> 기존 응답 조립 흐름 진행
```

이 방식은 목록 조회의 무거운 조건 검색과 페이지네이션 비용은 줄이면서, 사용자에게 보이는 카운트 값의 stale 정도를 낮추기 위한 절충안입니다.

---

### 6. 구독 공지 목록을 캐시하지 않은 이유

구독 공지 목록은 이번 PR의 캐시 대상에서 제외했습니다.

구독 공지 목록은 사용자마다 구독한 topic 조합이 다릅니다.

예시:

```text
A 사용자: SOFTWARE + SCHOLARSHIP
B 사용자: SOFTWARE + DORMITORY
C 사용자: SOFTWARE + SCHOLARSHIP + DORMITORY
```

같은 API라도 사용자별 결과 집합이 달라집니다. 여기에 star 같은 개인화 값까지 포함됩니다.

물론 topic set을 정렬한 뒤 hash를 만들어 캐시 키로 사용할 수는 있습니다.

```text
subscribed-events:{topic-set-hash}:page:0:size:10
```

하지만 이 경우 캐시 키 종류가 늘어나고, 구독 변경 시 무효화 전략도 추가로 필요합니다. 지금 단계에서는 캐시 효율과 정합성 리스크 대비 우선순위가 낮다고 판단했습니다.

따라서 이번 PR은 모두에게 거의 동일한 결과를 반환하는 타입별 공지 목록, 인기글, 배너에만 캐시를 적용합니다.

---

### 7. 주요 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `ClubEventCachePort` | 타입별 공지 목록, 인기글, 배너 캐시 메서드 추가 |
| `ClubEventCacheAdapter` | Redis JSON 저장/조회, SCAN 기반 타입 캐시 삭제 구현 |
| `ClubEventRepositoryPort` | cache hit 후 count 보정을 위한 `findAllByIds` 추가 |
| `ClubEventQueryService` | 타입별 공지 목록, 인기글, 배너 cache-aside 적용 |
| `ClubEventCommandService` | 새 공지 저장 후 타입별 목록 캐시와 인기글 캐시 evict |
| `PopularEventCacheScheduler` | 인기글 캐시 1시간 주기 warm-up |
| `FcmPushResultService` | FCM 발송 결과 success/fail counter 메트릭 추가 |
| `config/fcm.yaml`, `application-local.yaml` | FCM 부하테스트용 executor pool 설정 조정 |

---

### 8. 검증

- [x] `./gradlew compileJava`
- [x] `./gradlew spotlessCheck`
- [ ] `./gradlew test`

`./gradlew test`는 기존 테스트 환경의 Discord Feign URL placeholder 문제로 contextLoads에서 실패합니다.

```text
http://${DISCORD_WEBHOOK_URL} is malformed
```

이번 캐시 변경의 컴파일 및 포맷 검증은 통과했습니다.

## 📚 참고 자료(선택)

- V1 Redis 캐시 흐름 참고
  - 타입별 공지 목록 캐시
  - 인기 게시글 캐시 및 1시간 주기 갱신
  - 배너 캐시
- #78 Redis 더티 셋 패턴 기반 조회수 관리
