### PR TITLE
[Feat] 모니터링 환경구성 및 CICD 인프라 구성 #85

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,44 +12,84 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect app image changes
+        id: changes
+        run: |
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            changed_files="$(git ls-tree -r --name-only HEAD)"
+          else
+            changed_files="$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})"
+          fi
+
+          if echo "$changed_files" | grep -Eq '^(Dockerfile|build\.gradle|settings\.gradle|gradle/|gradlew|src/)'; then
+            echo "app_changed=true" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "app_changed=false" >> "$GITHUB_OUTPUT"
+            echo "image_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Log in to Docker Hub
+        if: steps.changes.outputs.app_changed == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Create Firebase service account file
+        if: steps.changes.outputs.app_changed == 'true'
         run: |
           mkdir -p src/main/resources/firebase
           echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > src/main/resources/firebase/firebase-service-account.json
 
       - name: Build and push Docker image
+        if: steps.changes.outputs.app_changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:latest
             ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:${{ github.sha }}
 
-      - name: Copy docker-compose.yml to EC2
+      - name: Copy deployment files to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
+          port: ${{ secrets.EC2_PORT }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: docker-compose.yml
+          source: "docker-compose.yml,monitoring"
           target: ~/ajouevent
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1
+        env:
+          APP_CHANGED: ${{ steps.changes.outputs.app_changed }}
+          APP_IMAGE: ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:${{ steps.changes.outputs.image_tag }}
+          APP_LATEST_IMAGE: ${{ secrets.DOCKER_USERNAME }}/ajouevent-be:latest
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
+          port: ${{ secrets.EC2_PORT }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: APP_CHANGED,APP_IMAGE,APP_LATEST_IMAGE
           script: |
             cd ~/ajouevent
-            DOCKER_IMAGE=${{ secrets.DOCKER_USERNAME }}/ajouevent-be:${{ github.sha }} docker compose pull app
-            DOCKER_IMAGE=${{ secrets.DOCKER_USERNAME }}/ajouevent-be:${{ github.sha }} docker compose up -d --no-deps app
+            if [ "$APP_CHANGED" = "true" ]; then
+              export DOCKER_IMAGE="$APP_IMAGE"
+              docker compose pull app
+            else
+              export DOCKER_IMAGE="$(docker inspect ajouevent-app --format '{{.Config.Image}}' 2>/dev/null || true)"
+              if [ -z "$DOCKER_IMAGE" ]; then
+                export DOCKER_IMAGE="$APP_LATEST_IMAGE"
+              fi
+            fi
+
+            docker compose up -d --pull missing
             docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Loki4j — 비동기 배치 로그 전송
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 dependencyManagement {

--- a/docker-compose.local.monitoring.yml
+++ b/docker-compose.local.monitoring.yml
@@ -1,0 +1,154 @@
+# 로컬 전체 스택 (앱 빌드 + 모니터링)
+#
+# 사용법:
+#   docker compose -f docker-compose.local.monitoring.yml up -d --build
+
+services:
+  app:
+    build: .
+    container_name: ajouevent-app-local
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      LOKI_URL: http://loki:3100
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - ajouevent-local
+
+  mysql:
+    image: mysql:8.0
+    container_name: ajouevent-mysql-local
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data_local:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - ajouevent-local
+
+  redis:
+    image: redis:7-alpine
+    container_name: ajouevent-redis-local
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data_local:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+    networks:
+      - ajouevent-local
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: ajouevent-prometheus-local
+    restart: unless-stopped
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus-local.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data_local:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-lifecycle
+    networks:
+      - ajouevent-local
+
+  loki:
+    image: grafana/loki:latest
+    container_name: ajouevent-loki-local
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data_local:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - ajouevent-local
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: ajouevent-grafana-local
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: false
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+    volumes:
+      - grafana_data_local:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - ajouevent-local
+
+  # macOS에서는 일부 메트릭이 제한될 수 있음
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: ajouevent-cadvisor-local
+    restart: unless-stopped
+    ports:
+      - "8181:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - ${HOME}/.docker/run/docker.sock:/var/run/docker.sock:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - ajouevent-local
+
+volumes:
+  mysql_data_local:
+    driver: local
+  redis_data_local:
+    driver: local
+  prometheus_data_local:
+    driver: local
+  loki_data_local:
+    driver: local
+  grafana_data_local:
+    driver: local
+
+networks:
+  ajouevent-local:
+    driver: bridge

--- a/docker-compose.local.monitoring.yml
+++ b/docker-compose.local.monitoring.yml
@@ -126,6 +126,9 @@ services:
     image: gcr.io/cadvisor/cadvisor:latest
     container_name: ajouevent-cadvisor-local
     restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "8181:8080"
     volumes:

--- a/docker-compose.local.monitoring.yml
+++ b/docker-compose.local.monitoring.yml
@@ -107,8 +107,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
       GF_USERS_ALLOW_SIGN_UP: false
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
       GF_USERS_ALLOW_SIGN_UP: false
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       REDIS_HOST: ajouevent-redis
       REDIS_PORT: 6379
+      LOKI_URL: http://loki:3100
     ports:
       - "8080:8080"
       - "9090:9090"
@@ -35,8 +36,88 @@ services:
     networks:
       - ajouevent-network
 
+  # ──────────────────────────────────────────────
+  # 모니터링 스택
+  # ──────────────────────────────────────────────
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: ajouevent-prometheus
+    restart: always
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+      - --web.enable-lifecycle
+    networks:
+      - ajouevent-network
+
+  loki:
+    image: grafana/loki:latest
+    container_name: ajouevent-loki
+    restart: always
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - ajouevent-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: ajouevent-grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: false
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - ajouevent-network
+
+  # Docker 컨테이너 메트릭 수집 (cAdvisor)
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: ajouevent-cadvisor
+    restart: always
+    privileged: true
+    ports:
+      - "8181:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    networks:
+      - ajouevent-network
+
 volumes:
   redis_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  loki_data:
+    driver: local
+  grafana_data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,9 @@ services:
     image: gcr.io/cadvisor/cadvisor:latest
     container_name: ajouevent-cadvisor
     restart: always
-    privileged: true
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "8181:8080"
     volumes:
@@ -104,9 +106,6 @@ services:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
     networks:
       - ajouevent-network
 

--- a/docs/observability-architecture.html
+++ b/docs/observability-architecture.html
@@ -1,0 +1,765 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AjouEvent 모니터링 인프라 구성도</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    :root {
+      --bg: #f6f8fb;
+      --surface: #ffffff;
+      --surface2: #eef4ff;
+      --surface3: #f8fafc;
+      --border: #d7e0ea;
+      --text: #172033;
+      --muted: #5f6f86;
+      --blue: #2563eb;
+      --blue-soft: #dbeafe;
+      --green: #059669;
+      --green-soft: #d1fae5;
+      --orange: #ea580c;
+      --orange-soft: #ffedd5;
+      --purple: #7c3aed;
+      --purple-soft: #ede9fe;
+      --red: #dc2626;
+      --yellow: #ca8a04;
+      --accent: #0891b2;
+      --shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      background:
+        radial-gradient(circle at 18% 0%, rgba(37, 99, 235, 0.12), transparent 28%),
+        radial-gradient(circle at 88% 10%, rgba(5, 150, 105, 0.10), transparent 24%),
+        linear-gradient(180deg, #fbfdff 0%, var(--bg) 260px);
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    /* ── Header ─────────────────────────────────────── */
+    header {
+      background: rgba(255, 255, 255, 0.78);
+      border-bottom: 1px solid var(--border);
+      padding: 40px 60px 32px;
+      box-shadow: 0 10px 30px rgba(37, 99, 235, 0.06);
+    }
+
+    header h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--text);
+      background: linear-gradient(90deg, #1d4ed8, #0891b2 54%, #059669);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 8px;
+    }
+
+    header p {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-left: 8px;
+      vertical-align: middle;
+    }
+
+    .badge-blue  { background: var(--blue-soft); color: #1d4ed8; border: 1px solid #bfdbfe; }
+    .badge-green { background: var(--green-soft); color: #047857; border: 1px solid #a7f3d0; }
+    .badge-orange{ background: var(--orange-soft); color: #c2410c; border: 1px solid #fed7aa; }
+
+    /* ── Nav ─────────────────────────────────────────── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      gap: 4px;
+      padding: 0 60px;
+      overflow-x: auto;
+    }
+
+    nav a {
+      display: block;
+      padding: 14px 16px;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      border-bottom: 2px solid transparent;
+      white-space: nowrap;
+      transition: color .15s, border-color .15s;
+    }
+
+    nav a:hover { color: var(--text); border-color: var(--blue); }
+
+    /* ── Main Layout ──────────────────────────────────── */
+    main { max-width: 1200px; margin: 0 auto; padding: 48px 60px; }
+
+    section { margin-bottom: 72px; scroll-margin-top: 60px; }
+
+    h2 {
+      font-size: 1.375rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    h2::before {
+      content: '';
+      display: block;
+      width: 4px;
+      height: 22px;
+      background: linear-gradient(180deg, var(--blue), var(--accent));
+      border-radius: 2px;
+    }
+
+    .section-desc {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-bottom: 28px;
+    }
+
+    /* ── Diagram Card ─────────────────────────────────── */
+    .diagram-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 32px;
+      overflow-x: auto;
+      box-shadow: var(--shadow);
+    }
+
+    .mermaid {
+      display: flex;
+      justify-content: center;
+    }
+
+    /* ── Component Cards ──────────────────────────────── */
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 16px;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px;
+      transition: border-color .15s, transform .15s, box-shadow .15s;
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+    }
+
+    .card:hover {
+      border-color: var(--blue);
+      transform: translateY(-2px);
+      box-shadow: 0 16px 36px rgba(37, 99, 235, 0.10);
+    }
+
+    .card-icon {
+      font-size: 1.75rem;
+      margin-bottom: 10px;
+    }
+
+    .card h3 {
+      font-size: 0.975rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+      color: var(--text);
+    }
+
+    .card .port {
+      font-family: 'Courier New', monospace;
+      font-size: 0.78rem;
+      color: var(--accent);
+      background: #ecfeff;
+      border: 1px solid #a5f3fc;
+      padding: 2px 8px;
+      border-radius: 4px;
+      margin-bottom: 10px;
+      display: inline-block;
+    }
+
+    .card p {
+      font-size: 0.83rem;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    /* ── Metrics Table ────────────────────────────────── */
+    .table-wrap {
+      overflow-x: auto;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+
+    thead tr {
+      background: var(--surface2);
+    }
+
+    th {
+      text-align: left;
+      padding: 12px 16px;
+      color: var(--muted);
+      font-weight: 600;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border-bottom: 1px solid var(--border);
+    }
+
+    td {
+      padding: 11px 16px;
+      border-bottom: 1px solid #e7edf5;
+      vertical-align: top;
+    }
+
+    tr:last-child td { border-bottom: none; }
+
+    tr:hover td { background: #f8fbff; }
+
+    .metric-name {
+      font-family: 'Courier New', monospace;
+      color: var(--accent);
+      font-size: 0.82rem;
+    }
+
+    .category-row td {
+      background: var(--surface2);
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 8px 16px;
+    }
+
+    /* ── Flow Info ────────────────────────────────────── */
+    .flow-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 16px;
+      margin-top: 24px;
+    }
+
+    .flow-item {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+    }
+
+    .flow-item h4 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+
+    .flow-item p {
+      font-size: 0.83rem;
+      color: var(--muted);
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 1px 8px;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-right: 4px;
+    }
+
+    .tag-metrics { background: var(--blue-soft); color: #1d4ed8; }
+    .tag-logs    { background: var(--green-soft); color: #047857; }
+    .tag-async   { background: var(--purple-soft); color: #6d28d9; }
+    .tag-docker  { background: var(--orange-soft); color: #c2410c; }
+
+    /* ── Footer ───────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 24px;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    code {
+      color: #0f766e;
+      background: #ecfeff;
+      border: 1px solid #a5f3fc;
+      border-radius: 5px;
+      padding: 1px 5px;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+      font-size: 0.88em;
+    }
+
+    @media (max-width: 760px) {
+      header { padding: 32px 22px 26px; }
+      header h1 { font-size: 1.55rem; }
+      nav { padding: 0 16px; }
+      main { padding: 36px 20px; }
+      .diagram-card { padding: 18px; }
+      .card-grid, .flow-grid { grid-template-columns: 1fr; }
+      th, td { padding: 10px 12px; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>AjouEvent 모니터링 인프라 구성도</h1>
+  <p>
+    Prometheus <span class="badge badge-blue">Metrics</span>
+    · Loki / Loki4j <span class="badge badge-green">Logs</span>
+    · Grafana <span class="badge badge-blue">Dashboard</span>
+    · cAdvisor <span class="badge badge-orange">Docker</span>
+    · MDC 비동기 컨텍스트 전파
+  </p>
+</header>
+
+<nav>
+  <a href="#architecture">전체 아키텍처</a>
+  <a href="#mdc">MDC 비동기 전파</a>
+  <a href="#dataflow">데이터 파이프라인</a>
+  <a href="#components">컴포넌트</a>
+  <a href="#metrics">메트릭 목록</a>
+</nav>
+
+<main>
+
+  <!-- ── Section 1: Architecture ─────────────────────── -->
+  <section id="architecture">
+    <h2>전체 아키텍처</h2>
+    <p class="section-desc">
+      단일 Spring Boot 서비스에 Prometheus(메트릭) · Loki(로그) · Grafana(대시보드) · cAdvisor(Docker 컨테이너)를
+      연결한 통합 관측 환경입니다. 모든 서비스는 동일한 Docker 브리지 네트워크를 공유합니다.
+    </p>
+    <div class="diagram-card">
+      <div class="mermaid">
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#ffffff', 'primaryColor': '#dbeafe', 'primaryTextColor': '#172033', 'primaryBorderColor': '#2563eb', 'secondaryColor': '#d1fae5', 'tertiaryColor': '#ffedd5', 'edgeLabelBackground': '#ffffff', 'lineColor': '#64748b'}}}%%
+graph LR
+    Browser["📱 Browser / Mobile"]
+
+    subgraph DockerNet["🐳 Docker Network — ajouevent-network"]
+        direction TB
+        subgraph AppLayer["Application"]
+            App["🚀 Spring Boot App\n:8080 API  :9090 Actuator"]
+            Redis["🔴 Redis 7\n:6379"]
+        end
+        subgraph MonLayer["Monitoring Stack"]
+            Prometheus["📊 Prometheus\n:9091"]
+            Loki["📋 Loki\n:3100"]
+            Grafana["📈 Grafana\n:3000"]
+            cAdvisor["🔍 cAdvisor\n:8181"]
+        end
+    end
+
+    subgraph External["☁️ 외부 서비스"]
+        FCM["🔔 Firebase FCM"]
+        MySQL["🗄️ MySQL / RDS"]
+        Discord["💬 Discord Webhook"]
+    end
+
+    Admin["👤 운영자"]
+
+    Browser -->|"HTTP API"| App
+    App <-->|"Cache · Pub/Sub"| Redis
+    App -->|"Push 발송"| FCM
+    App -->|"SQL"| MySQL
+    App -->|"에러 알림"| Discord
+
+    Prometheus -->|"Scrape 15s\n/actuator/prometheus"| App
+    Prometheus -->|"Scrape 15s\nDocker 메트릭"| cAdvisor
+    App -->|"Loki4j\n비동기 배치 Push"| Loki
+
+    Grafana -->|"PromQL"| Prometheus
+    Grafana -->|"LogQL"| Loki
+
+    Admin -->|"브라우저 :3000"| Grafana
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Section 2: MDC Async Propagation ───────────── -->
+  <section id="mdc">
+    <h2>MDC 비동기 컨텍스트 전파</h2>
+    <p class="section-desc">
+      HTTP 요청이 들어오면 <code>RequestIdFilter</code>가 UUID를 MDC에 삽입합니다.
+      <code>MdcTaskDecorator</code>가 FCM Executor에 적용되어 비동기 콜백 스레드로 MDC 스냅샷을 복사합니다.
+      덕분에 모든 로그에 <code>requestId</code>가 포함되어 Loki에서 단일 요청 흐름을 추적할 수 있습니다.
+    </p>
+    <div class="diagram-card">
+      <div class="mermaid">
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#ffffff', 'primaryColor': '#ede9fe', 'primaryTextColor': '#172033', 'primaryBorderColor': '#7c3aed', 'lineColor': '#64748b'}}}%%
+sequenceDiagram
+    participant H  as HTTP Request
+    participant F  as RequestIdFilter
+    participant C  as Controller
+    participant Ex as FCM Executor<br/>(MdcTaskDecorator)
+    participant T  as FCM Callback Thread
+    participant L  as Loki
+
+    H  ->> F  : 요청 수신
+    F  ->> F  : MDC.put("requestId", UUID.randomUUID())
+    F  ->> C  : filterChain.doFilter()
+    C  ->> Ex : executor.submit(fcmTask)
+
+    Note over Ex: MdcTaskDecorator<br/>contextMap = MDC.getCopyOfContextMap()
+
+    Ex ->> T  : 새 스레드 실행<br/>MDC.setContextMap(contextMap)
+    T  ->> T  : FCM 전송 (비동기)
+    T  ->> L  : 로그 전송<br/>requestId=abc-123 포함
+
+    Note over T: finally: MDC.clear()
+
+    F  ->> F  : finally: MDC.remove("requestId")
+    F  ->> H  : 응답 반환 (X-Request-ID: abc-123)
+      </div>
+    </div>
+
+    <div class="flow-grid">
+      <div class="flow-item">
+        <h4><span class="tag tag-async">RequestIdFilter</span> 역할</h4>
+        <p>모든 HTTP 요청에 대해 <code>X-Request-ID</code> 헤더를 읽거나, 없으면 UUID를 생성해 MDC에 삽입합니다.
+        응답 헤더로도 반환하므로 클라이언트에서 요청 추적이 가능합니다.</p>
+      </div>
+      <div class="flow-item">
+        <h4><span class="tag tag-async">MdcTaskDecorator</span> 역할</h4>
+        <p>Spring의 <code>TaskDecorator</code>를 구현해 FCM 콜백 Executor의 두 스레드풀
+        (<code>fcmCallbackExecutor</code>, <code>fcmDefaultExecutor</code>)에 적용됩니다.
+        부모 스레드의 MDC 스냅샷을 자식 스레드에 복사하고 실행 후 반드시 <code>MDC.clear()</code>합니다.</p>
+      </div>
+      <div class="flow-item">
+        <h4><span class="tag tag-logs">Loki에서 추적 쿼리</span></h4>
+        <p>Loki LogQL로 단일 요청 전체 로그를 조회할 수 있습니다.<br/>
+        <code>{application="ajouevent-be-v2"} |= "requestId=abc-123"</code><br/>
+        HTTP 스레드 → FCM 콜백 스레드까지 같은 requestId로 연결됩니다.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Section 3: Data Pipeline ───────────────────── -->
+  <section id="dataflow">
+    <h2>데이터 파이프라인</h2>
+    <p class="section-desc">
+      메트릭과 로그는 각각 독립된 파이프라인으로 Grafana에 수렴됩니다.
+      Prometheus는 Pull 방식으로 스크랩하고, Loki는 앱이 Push하는 구조입니다.
+    </p>
+    <div class="diagram-card">
+      <div class="mermaid">
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#ffffff', 'primaryColor': '#dbeafe', 'primaryTextColor': '#172033', 'primaryBorderColor': '#2563eb', 'secondaryColor': '#d1fae5', 'tertiaryColor': '#f8fafc', 'lineColor': '#64748b'}}}%%
+graph TD
+    subgraph MetricsPipeline["📊 메트릭 파이프라인 (Pull)"]
+        direction LR
+        A1["Spring Boot\nActuator\n/actuator/prometheus"] -->|"Scrape 15s"| P["Prometheus\n15일 보존"]
+        A2["cAdvisor\nDocker 메트릭"] -->|"Scrape 15s"| P
+    end
+
+    subgraph LogPipeline["📋 로그 파이프라인 (Push)"]
+        direction LR
+        B1["Logback\nLoki4j AsyncAppender"] -->|"배치 512건 or 3s"| Q["Loki\ntsdb + filesystem"]
+    end
+
+    P -->|"PromQL"| G["📈 Grafana\n통합 대시보드"]
+    Q -->|"LogQL"| G
+
+    style MetricsPipeline fill:#dbeafe,stroke:#2563eb
+    style LogPipeline    fill:#d1fae5,stroke:#059669
+      </div>
+    </div>
+
+    <div class="flow-grid">
+      <div class="flow-item">
+        <h4><span class="tag tag-metrics">Pull 방식 — Prometheus</span></h4>
+        <p>Prometheus가 15초마다 <code>/actuator/prometheus</code>에서 데이터를 가져갑니다.
+        앱이 다운되면 스크랩이 실패해 자동으로 공백 구간이 생기며, <code>up</code> 메트릭으로 장애를 감지할 수 있습니다.
+        보존 기간은 15일로 설정했습니다.</p>
+      </div>
+      <div class="flow-item">
+        <h4><span class="tag tag-logs">Push 방식 — Loki4j</span></h4>
+        <p>Loki4j의 비동기 배치 Appender가 로그를 모아서 일괄 전송합니다.
+        512건 또는 3초마다 한 번씩 <code>POST /loki/api/v1/push</code>를 호출합니다.
+        <code>ch.qos.logback.classic.AsyncAppender</code>로 한 번 더 감싸 앱 응답 지연을 최소화합니다.</p>
+      </div>
+      <div class="flow-item">
+        <h4><span class="tag tag-docker">cAdvisor — Docker 메트릭</span></h4>
+        <p>cAdvisor가 Docker 소켓과 cgroup을 직접 읽어 각 컨테이너의 CPU, 메모리, 네트워크 I/O를 수집합니다.
+        운영 환경에서는 컨테이너별 <code>id</code>와 네트워크 인터페이스 메트릭을 조합해 대시보드에 표시합니다.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Section 4: Components ──────────────────────── -->
+  <section id="components">
+    <h2>컴포넌트 상세</h2>
+    <p class="section-desc">각 서비스의 역할과 포트 정보입니다.</p>
+    <div class="card-grid">
+
+      <div class="card">
+        <div class="card-icon">🚀</div>
+        <h3>Spring Boot App</h3>
+        <div class="port">:8080 API · :9090 Actuator</div>
+        <p>메인 애플리케이션. <code>9090</code> 포트는 AWS 보안그룹에서 모니터링 IP로만 제한됩니다.
+        <code>/actuator/prometheus</code>에서 Micrometer 메트릭을 노출합니다.</p>
+      </div>
+
+      <div class="card">
+        <div class="card-icon">📊</div>
+        <h3>Prometheus</h3>
+        <div class="port">Host :9091 → Container :9090</div>
+        <p>Pull 방식 시계열 메트릭 DB. PromQL 쿼리 언어로 집계·분석. Grafana의 기본 데이터소스.
+        <code>--storage.tsdb.retention.time=15d</code>로 15일 보존.</p>
+      </div>
+
+      <div class="card">
+        <div class="card-icon">📋</div>
+        <h3>Loki</h3>
+        <div class="port">:3100</div>
+        <p>Prometheus와 동일한 레이블 모델을 사용하는 로그 집계 시스템. 로그 내용은 인덱싱하지 않아
+        ELK 대비 스토리지 비용이 낮습니다. LogQL로 로그 필터링·집계.</p>
+      </div>
+
+      <div class="card">
+        <div class="card-icon">📈</div>
+        <h3>Grafana</h3>
+        <div class="port">:3000</div>
+        <p>Prometheus(PromQL)와 Loki(LogQL)를 동시에 조회하는 통합 대시보드.
+        대시보드·데이터소스는 <code>monitoring/grafana/provisioning</code>으로 코드화하여 자동 프로비저닝됩니다.</p>
+      </div>
+
+      <div class="card">
+        <div class="card-icon">🔍</div>
+        <h3>cAdvisor</h3>
+        <div class="port">Host :8181 → Container :8080</div>
+        <p>Docker 컨테이너의 CPU · 메모리 · 네트워크 · 블록 I/O를 실시간 수집. privileged 권한과
+        Docker 소켓 마운트가 필요합니다. Prometheus가 15초마다 스크랩.</p>
+      </div>
+
+      <div class="card">
+        <div class="card-icon">🔴</div>
+        <h3>Redis 7</h3>
+        <div class="port">:6379</div>
+        <p>조회수 더티셋 패턴, 캐시, FCM 토큰 관리에 사용. AOF 영속성 활성화.
+        Spring Actuator Redis 메트릭이 Prometheus로 노출됩니다.</p>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── Section 5: Metrics ──────────────────────────── -->
+  <section id="metrics">
+    <h2>주요 메트릭 목록</h2>
+    <p class="section-desc">
+      Grafana 대시보드에 포함된 메트릭과 수집 방법입니다.
+      <code>application="ajouevent-be-v2"</code> 태그로 모든 앱 메트릭을 필터링합니다.
+    </p>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>메트릭 이름</th>
+            <th>유형</th>
+            <th>의미</th>
+            <th>출처</th>
+          </tr>
+        </thead>
+        <tbody>
+
+          <tr class="category-row"><td colspan="4">JVM</td></tr>
+          <tr>
+            <td class="metric-name">jvm_memory_used_bytes<br/>jvm_memory_max_bytes</td>
+            <td>Gauge</td>
+            <td>Heap · Non-Heap 사용량 및 최대 크기. area 태그로 구분</td>
+            <td>Micrometer JVM</td>
+          </tr>
+          <tr>
+            <td class="metric-name">jvm_gc_pause_seconds_sum/count</td>
+            <td>Timer</td>
+            <td>GC Pause 누적 시간과 횟수. rate()로 초당 GC 부하 계산</td>
+            <td>Micrometer JVM</td>
+          </tr>
+          <tr>
+            <td class="metric-name">jvm_threads_live_threads<br/>jvm_threads_peak_threads</td>
+            <td>Gauge</td>
+            <td>현재 활성·데몬·피크 스레드 수</td>
+            <td>Micrometer JVM</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">CPU & 시스템</td></tr>
+          <tr>
+            <td class="metric-name">process_cpu_usage<br/>system_cpu_usage</td>
+            <td>Gauge</td>
+            <td>JVM 프로세스 CPU와 전체 시스템 CPU 사용률 (0.0–1.0)</td>
+            <td>Micrometer Process</td>
+          </tr>
+          <tr>
+            <td class="metric-name">system_load_average_1m</td>
+            <td>Gauge</td>
+            <td>시스템 1분 로드 평균. CPU 코어 수 대비 부하 판단</td>
+            <td>Micrometer Process</td>
+          </tr>
+          <tr>
+            <td class="metric-name">process_files_open_files<br/>process_files_max_files</td>
+            <td>Gauge</td>
+            <td>열린 파일 디스크립터 수. 소켓 누수 감지에 활용</td>
+            <td>Micrometer Process</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">HTTP 요청</td></tr>
+          <tr>
+            <td class="metric-name">http_server_requests_seconds_count<br/>http_server_requests_seconds_sum</td>
+            <td>Counter / Timer</td>
+            <td>요청 수와 처리 시간. uri · method · status · outcome 태그</td>
+            <td>Spring Boot Actuator</td>
+          </tr>
+          <tr>
+            <td class="metric-name">http_server_requests_seconds_bucket</td>
+            <td>Histogram</td>
+            <td>레이턴시 버킷. histogram_quantile()로 P50·P95·P99 계산</td>
+            <td>Spring Boot Actuator</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">DB & Connection Pool</td></tr>
+          <tr>
+            <td class="metric-name">hikaricp_connections_active<br/>hikaricp_connections_idle<br/>hikaricp_connections_pending</td>
+            <td>Gauge</td>
+            <td>활성·유휴·대기 커넥션 수. pending 증가는 DB 과부하 신호</td>
+            <td>HikariCP Micrometer</td>
+          </tr>
+          <tr>
+            <td class="metric-name">hikaricp_connections_acquire_seconds<br/>hikaricp_connections_creation_seconds</td>
+            <td>Timer</td>
+            <td>커넥션 획득·생성 지연 시간. DB 레이턴시 지표로 활용</td>
+            <td>HikariCP Micrometer</td>
+          </tr>
+          <tr>
+            <td class="metric-name">hikaricp_connections_timeout_total</td>
+            <td>Counter</td>
+            <td>커넥션 획득 타임아웃 횟수. 증가 시 즉시 알림 설정 권장</td>
+            <td>HikariCP Micrometer</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">Thread Pool (Executor)</td></tr>
+          <tr>
+            <td class="metric-name">executor_active_threads<br/>executor_pool_size_threads<br/>executor_pool_max_threads</td>
+            <td>Gauge</td>
+            <td>fcm-callback · fcm-default · app-scheduler 각 풀의 활성·크기·최대 스레드</td>
+            <td>ExecutorServiceMetrics</td>
+          </tr>
+          <tr>
+            <td class="metric-name">executor_queued_tasks<br/>executor_completed_tasks_total</td>
+            <td>Gauge / Counter</td>
+            <td>대기 중인 작업 수와 완료 총량. 큐 증가 지속 시 풀 부족 신호</td>
+            <td>ExecutorServiceMetrics</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">FCM 알림 (커스텀)</td></tr>
+          <tr>
+            <td class="metric-name">notification_send_total{result="success|failure"}</td>
+            <td>Counter</td>
+            <td>FCM 전송 성공·실패 횟수. NotificationMetrics Bean 주입 후 recordSuccess() / recordFailure() 호출</td>
+            <td>NotificationMetrics (커스텀)</td>
+          </tr>
+          <tr>
+            <td class="metric-name">notification_send_duration_seconds_bucket</td>
+            <td>Histogram</td>
+            <td>FCM 전송 소요 시간 히스토그램. P50·P95·P99 추적</td>
+            <td>NotificationMetrics (커스텀)</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">Docker 컨테이너 (cAdvisor)</td></tr>
+          <tr>
+            <td class="metric-name">container_cpu_usage_seconds_total</td>
+            <td>Counter</td>
+            <td>컨테이너 CPU 사용 누적 초. rate()로 사용률 계산</td>
+            <td>cAdvisor</td>
+          </tr>
+          <tr>
+            <td class="metric-name">container_memory_usage_bytes<br/>container_memory_working_set_bytes</td>
+            <td>Gauge</td>
+            <td>컨테이너 메모리 사용량. working_set은 실제 회수 불가 메모리</td>
+            <td>cAdvisor</td>
+          </tr>
+          <tr>
+            <td class="metric-name">container_network_transmit_bytes_total<br/>container_network_receive_bytes_total</td>
+            <td>Counter</td>
+            <td>컨테이너 네트워크 송신·수신 누적 바이트</td>
+            <td>cAdvisor</td>
+          </tr>
+
+          <tr class="category-row"><td colspan="4">로그 이벤트 (Logback)</td></tr>
+          <tr>
+            <td class="metric-name">logback_events_total{level="error|warn|info|debug"}</td>
+            <td>Counter</td>
+            <td>레벨별 로그 발생 횟수. error 급증은 장애 초기 신호</td>
+            <td>Micrometer Logback</td>
+          </tr>
+
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  AjouEvent Monitoring Infrastructure · Prometheus + Loki + Grafana + cAdvisor
+</footer>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      background: '#ffffff',
+      primaryColor: '#dbeafe',
+      primaryTextColor: '#172033',
+      primaryBorderColor: '#2563eb',
+      lineColor: '#64748b',
+      secondaryColor: '#d1fae5',
+      tertiaryColor: '#ffedd5',
+      noteBkgColor: '#fff7ed',
+      noteTextColor: '#172033'
+    },
+    flowchart: { curve: 'basis', padding: 20 },
+    sequence: { actorMargin: 60, messageMargin: 30 }
+  });
+
+  // Smooth scroll for nav links
+  document.querySelectorAll('nav a').forEach(a => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      const target = document.querySelector(a.getAttribute('href'));
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+</script>
+</body>
+</html>

--- a/monitoring/grafana/dashboards/ajouevent.json
+++ b/monitoring/grafana/dashboards/ajouevent.json
@@ -1,0 +1,750 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "AjouEvent 통합 모니터링 — JVM · HTTP · DB · ThreadPool · FCM · Docker",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 10}, {"color": "red", "value": 50}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\"}[1m]))", "legendFormat": "RPS", "refId": "A"}
+      ],
+      "title": "총 요청 처리율 (RPS)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",outcome=~\"CLIENT_ERROR|SERVER_ERROR\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"$application\"}[1m])) * 100", "legendFormat": "Error %", "refId": "A"}
+      ],
+      "title": "HTTP 에러율",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 90}]},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showThresholdLabels": false, "showThresholdMarkers": true},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{application=\"$application\",area=\"heap\"}) / sum(jvm_memory_max_bytes{application=\"$application\",area=\"heap\"}) * 100", "legendFormat": "Heap %", "refId": "A"}
+      ],
+      "title": "JVM Heap 사용률",
+      "type": "gauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 60}, {"color": "red", "value": 85}]},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_cpu_usage{application=\"$application\"} * 100", "legendFormat": "Process CPU", "refId": "A"}
+      ],
+      "title": "프로세스 CPU 사용률",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4},
+      "id": 10,
+      "title": "JVM & 메모리",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "id": 11,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{application=\"$application\",area=\"heap\"})", "legendFormat": "Used", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_committed_bytes{application=\"$application\",area=\"heap\"})", "legendFormat": "Committed", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_max_bytes{application=\"$application\",area=\"heap\"})", "legendFormat": "Max", "refId": "C"}
+      ],
+      "title": "JVM Heap 메모리",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "id": 12,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{application=\"$application\",area=\"nonheap\"})", "legendFormat": "Non-Heap Used", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_committed_bytes{application=\"$application\",area=\"nonheap\"})", "legendFormat": "Non-Heap Committed", "refId": "B"}
+      ],
+      "title": "JVM Non-Heap 메모리",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+      "id": 13,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(jvm_gc_pause_seconds_sum{application=\"$application\"}[1m])", "legendFormat": "{{action}} {{cause}}", "refId": "A"}
+      ],
+      "title": "GC Pause (초/분)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "id": 14,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_live_threads{application=\"$application\"}", "legendFormat": "Live", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_daemon_threads{application=\"$application\"}", "legendFormat": "Daemon", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_peak_threads{application=\"$application\"}", "legendFormat": "Peak", "refId": "C"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_states_threads{application=\"$application\"}", "legendFormat": "{{state}}", "refId": "D"}
+      ],
+      "title": "JVM 스레드",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
+      "id": 20,
+      "title": "CPU & 시스템",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
+      "id": 21,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_cpu_usage{application=\"$application\"}", "legendFormat": "Process CPU", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "system_cpu_usage{application=\"$application\"}", "legendFormat": "System CPU", "refId": "B"}
+      ],
+      "title": "CPU 사용률",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
+      "id": 22,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "system_load_average_1m{application=\"$application\"}", "legendFormat": "Load Avg 1m", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_files_open_files{application=\"$application\"}", "legendFormat": "Open FDs", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_files_max_files{application=\"$application\"}", "legendFormat": "Max FDs", "refId": "C"}
+      ],
+      "title": "시스템 로드 & 파일 디스크립터",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 30},
+      "id": 30,
+      "title": "HTTP 요청",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 31},
+      "id": 31,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\"}[1m])) by (uri, method, status)", "legendFormat": "{{method}} {{uri}} ({{status}})", "refId": "A"}
+      ],
+      "title": "HTTP 요청률 (URI별)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 39},
+      "id": 32,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P95", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P99", "refId": "C"}
+      ],
+      "title": "HTTP 레이턴시 백분위 (P50 / P95 / P99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 39},
+      "id": 33,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",outcome=~\"CLIENT_ERROR|SERVER_ERROR\"}[1m])) by (status, uri)", "legendFormat": "{{status}} {{uri}}", "refId": "A"}
+      ],
+      "title": "HTTP 에러 (4xx / 5xx)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 47},
+      "id": 40,
+      "title": "DB & Connection Pool (HikariCP)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 48},
+      "id": 41,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "hikaricp_connections_active{application=\"$application\"}", "legendFormat": "Active", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "hikaricp_connections_idle{application=\"$application\"}", "legendFormat": "Idle", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "hikaricp_connections_pending{application=\"$application\"}", "legendFormat": "Pending", "refId": "C"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "hikaricp_connections_max{application=\"$application\"}", "legendFormat": "Max", "refId": "D"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "hikaricp_connections_timeout_total{application=\"$application\"}", "legendFormat": "Timeout Total", "refId": "E"}
+      ],
+      "title": "HikariCP 커넥션 풀 상태",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 48},
+      "id": 42,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(hikaricp_connections_acquire_seconds_sum{application=\"$application\"}[1m]) / rate(hikaricp_connections_acquire_seconds_count{application=\"$application\"}[1m]) * 1000", "legendFormat": "Avg Acquire", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(hikaricp_connections_creation_seconds_sum{application=\"$application\"}[1m]) / rate(hikaricp_connections_creation_seconds_count{application=\"$application\"}[1m]) * 1000", "legendFormat": "Avg Creation", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(hikaricp_connections_usage_seconds_sum{application=\"$application\"}[1m]) / rate(hikaricp_connections_usage_seconds_count{application=\"$application\"}[1m]) * 1000", "legendFormat": "Avg Usage", "refId": "C"}
+      ],
+      "title": "HikariCP 커넥션 지연 시간 (ms)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 56},
+      "id": 50,
+      "title": "Thread Pool (Executor)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 57},
+      "id": 51,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "executor_active_threads{application=\"$application\"}", "legendFormat": "Active — {{name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "executor_pool_size_threads{application=\"$application\"}", "legendFormat": "Pool Size — {{name}}", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "executor_pool_max_threads{application=\"$application\"}", "legendFormat": "Max — {{name}}", "refId": "C"}
+      ],
+      "title": "Executor Active / Pool 스레드 수",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 57},
+      "id": 52,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "executor_queued_tasks{application=\"$application\"}", "legendFormat": "Queued — {{name}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "executor_queue_remaining_tasks{application=\"$application\"}", "legendFormat": "Queue Remaining — {{name}}", "refId": "B"}
+      ],
+      "title": "Executor 큐 대기 작업",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 65},
+      "id": 53,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(executor_completed_tasks_total{application=\"$application\"}[1m])", "legendFormat": "Completed/s — {{name}}", "refId": "A"}
+      ],
+      "title": "Executor 완료 작업 처리율",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 73},
+      "id": 60,
+      "title": "알림 (FCM Push)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 74},
+      "id": 61,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "increase(notification_send_total{application=\"$application\",result=\"success\"}[1h])", "legendFormat": "Success (1h)", "refId": "A"}
+      ],
+      "title": "FCM 전송 성공 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 10}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 74},
+      "id": 62,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "increase(notification_send_total{application=\"$application\",result=\"failure\"}[1h])", "legendFormat": "Failure (1h)", "refId": "A"}
+      ],
+      "title": "FCM 전송 실패 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 74},
+      "id": 63,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "increase(logback_events_total{application=\"$application\",level=\"error\"}[1h])", "legendFormat": "Errors (1h)", "refId": "A"}
+      ],
+      "title": "로그 에러 발생 수 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 74},
+      "id": 64,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "increase(logback_events_total{application=\"$application\",level=\"warn\"}[1h])", "legendFormat": "Warnings (1h)", "refId": "A"}
+      ],
+      "title": "로그 경고 발생 수 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 78},
+      "id": 65,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(notification_send_total{application=\"$application\",result=\"success\"}[1m])", "legendFormat": "Success/s", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(notification_send_total{application=\"$application\",result=\"failure\"}[1m])", "legendFormat": "Failure/s", "refId": "B"}
+      ],
+      "title": "FCM 전송 처리율 (성공 / 실패)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 78},
+      "id": 66,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.50, sum(rate(notification_send_duration_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.95, sum(rate(notification_send_duration_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P95", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.99, sum(rate(notification_send_duration_seconds_bucket{application=\"$application\"}[5m])) by (le))", "legendFormat": "P99", "refId": "C"}
+      ],
+      "title": "FCM 전송 소요 시간 (P50 / P95 / P99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 86},
+      "id": 70,
+      "title": "Docker 컨테이너 (cAdvisor)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 87},
+      "id": 71,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(container_cpu_usage_seconds_total{job=\"cadvisor\",id=~\"/docker/.+\"}[1m])", "legendFormat": "{{id}}", "refId": "A"}
+      ],
+      "title": "컨테이너 CPU 사용률",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 87},
+      "id": 72,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_usage_bytes{job=\"cadvisor\",id=~\"/docker/.+\"}", "legendFormat": "{{id}} Usage", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_working_set_bytes{job=\"cadvisor\",id=~\"/docker/.+\"}", "legendFormat": "{{id}} Working Set", "refId": "B"}
+      ],
+      "title": "컨테이너 메모리 사용량",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 95},
+      "id": 73,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(container_network_transmit_bytes_total{job=\"cadvisor\",id=\"/\",interface=~\"eth0|br-.+|services.+\"}[1m])", "legendFormat": "TX {{interface}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(container_network_receive_bytes_total{job=\"cadvisor\",id=\"/\",interface=~\"eth0|br-.+|services.+\"}[1m])", "legendFormat": "RX {{interface}}", "refId": "B"}
+      ],
+      "title": "컨테이너 네트워크 I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 95},
+      "id": 74,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(logback_events_total{application=\"$application\"}[1m])", "legendFormat": "{{level}}", "refId": "A"}
+      ],
+      "title": "로그 이벤트 발생률 (레벨별)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 103},
+      "id": 80,
+      "title": "애플리케이션 로그 (Loki)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 14, "w": 24, "x": 0, "y": 104},
+      "id": 81,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
+      "targets": [
+        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{application=\"ajouevent-be-v2\", level=~\"$level\"}", "refId": "A"}
+      ],
+      "title": "실시간 애플리케이션 로그",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["ajouevent", "spring-boot", "monitoring"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "ajouevent-be-v2", "value": "ajouevent-be-v2"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(jvm_memory_used_bytes, application)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Application",
+        "multi": false,
+        "name": "application",
+        "options": [],
+        "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "StandardVariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": "ERROR|WARN|INFO|DEBUG|TRACE",
+        "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+        "hide": 0,
+        "includeAll": true,
+        "label": "Log Level",
+        "multi": true,
+        "name": "level",
+        "options": [
+          {"selected": true, "text": "All", "value": "$__all"},
+          {"selected": false, "text": "ERROR", "value": "ERROR"},
+          {"selected": false, "text": "WARN", "value": "WARN"},
+          {"selected": false, "text": "INFO", "value": "INFO"},
+          {"selected": false, "text": "DEBUG", "value": "DEBUG"}
+        ],
+        "query": "ERROR,WARN,INFO,DEBUG",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AjouEvent 통합 모니터링",
+  "uid": "ajouevent-monitoring",
+  "version": 1
+}

--- a/monitoring/grafana/dashboards/ajouevent.json
+++ b/monitoring/grafana/dashboards/ajouevent.json
@@ -694,7 +694,7 @@
       "id": 81,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
       "targets": [
-        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{application=\"ajouevent-be-v2\", level=~\"$level\"}", "refId": "A"}
+        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{application=\"$application\", level=~\"$level\"}", "refId": "A"}
       ],
       "title": "실시간 애플리케이션 로그",
       "type": "logs"

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: AjouEvent
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -20,7 +20,7 @@ datasources:
     editable: false
     jsonData:
       derivedFields:
-        - matcherRegex: requestId=(\S+)
+        - matcherRegex: 'requestId="([^"]+)"'
           name: RequestID
           url: ${__value.raw}
           urlDisplayLabel: RequestID

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,26 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      exemplarTraceIdDestinations: []
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    access: proxy
+    editable: false
+    jsonData:
+      derivedFields:
+        - matcherRegex: requestId=(\S+)
+          name: RequestID
+          url: ${__value.raw}
+          urlDisplayLabel: RequestID

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -28,6 +28,3 @@ schema_config:
 limits_config:
   allow_structured_metadata: true
   volume_enabled: true
-
-ruler:
-  alertmanager_url: http://localhost:9093

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,33 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/monitoring/prometheus/prometheus-local.yml
+++ b/monitoring/prometheus/prometheus-local.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+
+  - job_name: ajouevent-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - app:9090
+
+  - job_name: cadvisor
+    static_configs:
+      - targets:
+          - cadvisor:8080

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+
+  - job_name: ajouevent-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - app:9090
+
+  - job_name: cadvisor
+    static_configs:
+      - targets:
+          - cadvisor:8080

--- a/src/main/java/com/example/ajouevent_be_v2/common/metrics/NotificationMetrics.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/metrics/NotificationMetrics.java
@@ -27,7 +27,6 @@ public class NotificationMetrics {
             .register(registry);
         this.sendTimer = Timer.builder("notification.send.duration")
             .description("FCM 알림 전송 소요 시간")
-            .publishPercentiles(0.5, 0.95, 0.99)
             .publishPercentileHistogram()
             .register(registry);
     }

--- a/src/main/java/com/example/ajouevent_be_v2/common/metrics/NotificationMetrics.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/metrics/NotificationMetrics.java
@@ -1,0 +1,46 @@
+package com.example.ajouevent_be_v2.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+/**
+ * FCM 알림 전송 결과 및 소요 시간을 추적하는 커스텀 메트릭.
+ * 전송 서비스에서 주입받아 recordSuccess() / recordFailure() / getSendTimer() 를 호출한다.
+ */
+@Component
+public class NotificationMetrics {
+
+    private final Counter successCounter;
+    private final Counter failureCounter;
+    private final Timer sendTimer;
+
+    public NotificationMetrics(MeterRegistry registry) {
+        this.successCounter = Counter.builder("notification.send")
+            .tag("result", "success")
+            .description("FCM 알림 전송 성공 횟수")
+            .register(registry);
+        this.failureCounter = Counter.builder("notification.send")
+            .tag("result", "failure")
+            .description("FCM 알림 전송 실패 횟수")
+            .register(registry);
+        this.sendTimer = Timer.builder("notification.send.duration")
+            .description("FCM 알림 전송 소요 시간")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .publishPercentileHistogram()
+            .register(registry);
+    }
+
+    public void recordSuccess() {
+        successCounter.increment();
+    }
+
+    public void recordFailure() {
+        failureCounter.increment();
+    }
+
+    public Timer getSendTimer() {
+        return sendTimer;
+    }
+}

--- a/src/main/java/com/example/ajouevent_be_v2/common/trace/MdcTaskDecorator.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/trace/MdcTaskDecorator.java
@@ -1,0 +1,28 @@
+package com.example.ajouevent_be_v2.common.trace;
+
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비동기 스레드로 MDC 컨텍스트(requestId 등)를 전파하는 TaskDecorator.
+ * FCM 콜백 Executor, 기본 Executor 등 ThreadPoolTaskExecutor에 적용한다.
+ */
+@Component
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        return () -> {
+            try {
+                MDC.setContextMap(contextMap != null ? contextMap : Collections.emptyMap());
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/ajouevent_be_v2/common/trace/RequestIdFilter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/trace/RequestIdFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -15,7 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * 모든 HTTP 요청에 requestId(UUID)를 MDC에 삽입하는 필터.
  * MdcTaskDecorator와 함께 동작하여 비동기 스레드까지 requestId가 전파된다.
- * X-Request-ID 헤더가 있으면 재사용, 없으면 신규 생성.
+ * X-Request-ID 헤더가 안전한 형식이면 재사용, 없거나 유효하지 않으면 신규 생성.
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -23,16 +24,15 @@ public class RequestIdFilter extends OncePerRequestFilter {
 
     private static final String REQUEST_ID_HEADER = "X-Request-ID";
     private static final String MDC_KEY = "requestId";
+    private static final int MAX_REQUEST_ID_LENGTH = 128;
+    private static final Pattern REQUEST_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._:-]+$");
 
     @Override
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
-        String requestId = request.getHeader(REQUEST_ID_HEADER);
-        if (requestId == null || requestId.isBlank()) {
-            requestId = UUID.randomUUID().toString();
-        }
+        String requestId = resolveRequestId(request.getHeader(REQUEST_ID_HEADER));
         MDC.put(MDC_KEY, requestId);
         response.setHeader(REQUEST_ID_HEADER, requestId);
         try {
@@ -40,5 +40,19 @@ public class RequestIdFilter extends OncePerRequestFilter {
         } finally {
             MDC.remove(MDC_KEY);
         }
+    }
+
+    private String resolveRequestId(String requestId) {
+        if (isValidRequestId(requestId)) {
+            return requestId;
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    private boolean isValidRequestId(String requestId) {
+        return requestId != null
+                && !requestId.isBlank()
+                && requestId.length() <= MAX_REQUEST_ID_LENGTH
+                && REQUEST_ID_PATTERN.matcher(requestId).matches();
     }
 }

--- a/src/main/java/com/example/ajouevent_be_v2/common/trace/RequestIdFilter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/trace/RequestIdFilter.java
@@ -1,0 +1,44 @@
+package com.example.ajouevent_be_v2.common.trace;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 모든 HTTP 요청에 requestId(UUID)를 MDC에 삽입하는 필터.
+ * MdcTaskDecorator와 함께 동작하여 비동기 스레드까지 requestId가 전파된다.
+ * X-Request-ID 헤더가 있으면 재사용, 없으면 신규 생성.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+    private static final String MDC_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        MDC.put(MDC_KEY, requestId);
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_KEY);
+        }
+    }
+}

--- a/src/main/java/com/example/ajouevent_be_v2/config/FcmConfig.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/FcmConfig.java
@@ -1,5 +1,6 @@
 package com.example.ajouevent_be_v2.config;
 
+import com.example.ajouevent_be_v2.common.trace.MdcTaskDecorator;
 import com.example.ajouevent_be_v2.config.properties.FcmExecutorProperties;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -16,6 +17,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class FcmConfig {
 
     private final FcmExecutorProperties fcmExecutorProperties;
+    private final MdcTaskDecorator mdcTaskDecorator;
 
     @Bean(name = "fcmCallbackExecutor")
     public ThreadPoolTaskExecutor fcmCallbackExecutor() {
@@ -27,6 +29,7 @@ public class FcmConfig {
         executor.setThreadNamePrefix("fcm-callback-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(pool.getAwaitTerminationSeconds());
+        executor.setTaskDecorator(mdcTaskDecorator);
         executor.initialize();
         return executor;
     }
@@ -51,6 +54,7 @@ public class FcmConfig {
         executor.setThreadNamePrefix("fcm-default-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(pool.getAwaitTerminationSeconds());
+        executor.setTaskDecorator(mdcTaskDecorator);
         executor.initialize();
         return executor;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,12 +38,8 @@ management:
     distribution:
       percentiles-histogram:
         # 히스토그램 버킷 활성화 — Prometheus에서 histogram_quantile()로 정확한 레이턴시 분위수 계산 가능
-        # 비활성화 시 percentiles 값은 앱 내부 추정값(부정확)으로만 노출됨
         http.server.requests: true
         notification.send.duration: true
-      percentiles:
-        http.server.requests: 0.5, 0.95, 0.99
-        notification.send.duration: 0.5, 0.95, 0.99
 
 ajou:
   scheduler:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,8 +40,10 @@ management:
         # 히스토그램 버킷 활성화 — Prometheus에서 histogram_quantile()로 정확한 레이턴시 분위수 계산 가능
         # 비활성화 시 percentiles 값은 앱 내부 추정값(부정확)으로만 노출됨
         http.server.requests: true
+        notification.send.duration: true
       percentiles:
         http.server.requests: 0.5, 0.95, 0.99
+        notification.send.duration: 0.5, 0.95, 0.99
 
 ajou:
   scheduler:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="ajouevent-be-v2"/>
+  <property name="LOKI_URL" value="${LOKI_URL:-http://loki:3100}"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} requestId=%X{requestId:-} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Loki4j 비동기 배치 Appender -->
+  <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+    <http>
+      <url>${LOKI_URL}/loki/api/v1/push</url>
+      <connectionTimeoutMs>5000</connectionTimeoutMs>
+      <requestTimeoutMs>5000</requestTimeoutMs>
+    </http>
+    <format>
+      <label>
+        <!-- Loki 스트림 레이블: application, level 은 고정 카디널리티로 유지 -->
+        <pattern>application=${APP_NAME},level=%level</pattern>
+      </label>
+      <message>
+        <!-- 구조화된 key=value 포맷 — Grafana LogQL 파싱 및 requestId 링크에 활용 -->
+        <pattern>level="%level" application="${APP_NAME}" requestId="%X{requestId:-}" thread="%thread" logger="%logger{36}" message="%msg"%n</pattern>
+      </message>
+      <sortByTime>true</sortByTime>
+    </format>
+    <batchMaxItems>512</batchMaxItems>
+    <batchTimeoutMs>3000</batchTimeoutMs>
+    <verbose>false</verbose>
+  </appender>
+
+  <!-- LOKI Appender 를 비동기로 감싸 로깅이 앱 성능에 영향을 주지 않도록 함 -->
+  <appender name="ASYNC_LOKI" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="LOKI"/>
+    <queueSize>4096</queueSize>
+    <discardingThreshold>0</discardingThreshold>
+    <neverBlock>true</neverBlock>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="ASYNC_LOKI"/>
+  </root>
+
+  <logger name="com.example.ajouevent_be_v2" level="DEBUG" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="ASYNC_LOKI"/>
+  </logger>
+
+  <!-- 불필요한 노이즈 로그 억제 -->
+  <logger name="org.springframework.web" level="WARN"/>
+  <logger name="org.hibernate.SQL" level="WARN"/>
+  <logger name="com.zaxxer.hikari" level="WARN"/>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
   <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="ajouevent-be-v2"/>
-  <property name="LOKI_URL" value="${LOKI_URL:-http://loki:3100}"/>
+  <springProperty scope="context" name="LOKI_URL" source="LOKI_URL" defaultValue="http://loki:3100"/>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #85

## 💡 작업 내용

### 애플리케이션 관측성 추가

- Spring Boot Actuator + Prometheus 메트릭 노출 구성을 확장했습니다.
- Loki4j Logback appender를 추가해 애플리케이션 로그를 Loki로 전송하도록 구성했습니다.
- 모든 HTTP 요청에 `requestId`를 부여하고 MDC에 저장하는 `RequestIdFilter`를 추가했습니다.
- FCM 비동기 executor에서도 `requestId`가 유지되도록 `MdcTaskDecorator`를 적용했습니다.
- 알림 전송 성공/실패 및 전송 시간 추적을 위한 `NotificationMetrics`를 추가했습니다.

### 모니터링 스택 구성

- Prometheus, Loki, Grafana, cAdvisor 기반 모니터링 스택을 Docker Compose에 추가했습니다.
- 로컬 전체 스택 실행을 위한 `docker-compose.local.monitoring.yml`을 추가했습니다.
- Grafana datasource와 dashboard provisioning을 코드로 관리하도록 구성했습니다.
- Loki 로그 레벨 라벨이 대문자로 수집되는 점에 맞춰 Grafana 로그 필터 변수를 `ERROR`, `WARN`, `INFO`, `DEBUG` 기준으로 수정했습니다.

### 배포 CI/CD 개선

- GitHub Actions 배포 workflow에서 `docker-compose.yml`뿐 아니라 `monitoring/` 디렉터리도 EC2로 복사하도록 변경했습니다.
- 배포 시 앱뿐 아니라 Redis, Prometheus, Loki, Grafana, cAdvisor가 함께 compose 스택으로 올라가도록 변경했습니다.
- 앱 이미지에 영향을 주는 파일이 변경된 경우에만 Docker 이미지를 build/push하도록 조건부 빌드 로직을 추가했습니다.
- Docker build cache를 GitHub Actions cache로 사용하도록 설정했습니다.

## 📝 추가 설명(선택)

배포 후 확인 대상은 다음과 같습니다.

```text
Grafana    : http://<server-host>:3000
Prometheus : http://<server-host>:9091
cAdvisor   : http://<server-host>:8181
```

## 📚 참고 자료(선택)

- Grafana datasource provisioning: `monitoring/grafana/provisioning/datasources/datasources.yml`
- Grafana dashboard: `monitoring/grafana/dashboards/ajouevent.json`
- Prometheus scrape config: `monitoring/prometheus/prometheus.yml`
- Loki config: `monitoring/loki/loki-config.yml`
- 배포 workflow: `.github/workflows/deploy.yml`
