### PR TITLE
[Hotfix] JsonProcessingException 제거 #89

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/clubevent/ClubEventCacheAdapter.java
@@ -5,9 +5,9 @@ import com.example.ajouevent_be_v2.domain.clubevent.EventBanner;
 import com.example.ajouevent_be_v2.domain.clubevent.Type;
 import com.example.ajouevent_be_v2.dto.clubevent.ClubEventSummaryResult;
 import com.example.ajouevent_be_v2.repository.port.clubevent.ClubEventCachePort;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -223,7 +223,7 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
         }
         try {
             return Optional.of(objectMapper.readValue(json, typeReference));
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             stringRedisTemplate.delete(key);
             return Optional.empty();
         }
@@ -235,7 +235,7 @@ public class ClubEventCacheAdapter implements ClubEventCachePort {
                 key,
                 objectMapper.writeValueAsString(value),
                 ttl);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("ClubEvent cache serialization failed", e);
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈

> Closes #89 

## 💡 작업 내용

코드 본문에서 예외 타입을 JsonProcessingException으로 남겨둔 게 문제 해경

Spring Boot 4 / Jackson 3 기준으로는 이렇게 통일

```java
import tools.jackson.core.JacksonException;
import tools.jackson.core.type.TypeReference;
import tools.jackson.databind.ObjectMapper;
```

catch도 전부:

```
catch (JacksonException e)
```

로 변경