### PR TITLE
[Bug] Docker 네트워크 MTU 1450 설정 추가 #96

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -52,3 +52,5 @@ volumes:
 networks:
   ajouevent-network:
     driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1450

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,3 +122,5 @@ volumes:
 networks:
   ajouevent-network:
     driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1450


### PR DESCRIPTION
## 🔗 관련 이슈

#96

## 💡 작업 내용

- 운영 Docker bridge 네트워크 `ajouevent-network`에 MTU 1450 옵션을 추가했습니다.
- 로컬 Docker compose 네트워크 정의에도 동일한 MTU 옵션을 추가했습니다.
- 아올다 인스턴스 host NIC MTU 1450과 Docker bridge/container MTU 1500 불일치로 인해 크롤러 컨테이너에서 아주대학교 HTTPS TLS handshake timeout이 발생하는 상황을 완화하기 위한 변경입니다.

## 📝 추가 설명(선택)

기존에 생성된 Docker network는 compose 파일 수정만으로 MTU가 즉시 바뀌지 않습니다. 운영 반영 시에는 점검 시간에 `ajouevent_ajouevent-network`를 사용하는 컨테이너를 재생성하여 새 네트워크 설정이 적용되도록 해야 합니다.

검증:
- `docker compose config`로 prod/local compose 파싱 확인

## 📚 참고 자료(선택)

- host `ens3` MTU: 1450
- 운영 Docker bridge/container MTU: 1500
- host에서는 아주대학교 HTTPS 정상
- crawler network namespace에서는 TCP 443 연결 후 TLS ClientHello 이후 timeout 재현