### PR TITLE
[Chore] 배포 워크플로우 수동 실행 트리거 추가 #98

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## 🔗 관련 이슈

#98

## 💡 작업 내용

- `Deploy to EC2` workflow에 `workflow_dispatch` 트리거를 추가했습니다.
- 기존 `main` push 자동 배포 트리거는 그대로 유지했습니다.
- push 이벤트로 workflow run이 생성되지 않는 상황에서도 GitHub Actions 화면에서 수동으로 배포를 실행할 수 있게 했습니다.

## 📝 추가 설명(선택)

이번 변경은 배포 로직을 바꾸지 않고 실행 트리거만 추가합니다. merge 후 Actions 화면에서 `Run workflow` 버튼이 노출되는지 확인하면 됩니다.

## 📚 참고 자료(선택)

- `workflow_dispatch`: GitHub Actions workflow를 UI/API에서 수동 실행할 수 있게 하는 트리거입니다.
- 검증: workflow YAML 파싱 확인