### PR TITLE
[Bug] 캘린더 토큰 영속 볼륨 설정 추가 #95

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     ports:
       - "8080:8080"
       - "9090:9090"
+    volumes:
+      - calendar_tokens:/app/tokens
     depends_on:
       redis:
         condition: service_healthy
@@ -117,6 +119,8 @@ volumes:
   loki_data:
     driver: local
   grafana_data:
+    driver: local
+  calendar_tokens:
     driver: local
 
 networks:

--- a/src/main/java/com/example/ajouevent_be_v2/config/properties/GoogleProperties.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/properties/GoogleProperties.java
@@ -15,4 +15,5 @@ public class GoogleProperties {
     private String tokenEndpoint;
     private String calendarApiUrl;
     private String peopleApiUrl;
+    private String tokenDirectory;
 }

--- a/src/main/java/com/example/ajouevent_be_v2/service/calendar/CalendarCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/calendar/CalendarCommandService.java
@@ -32,7 +32,7 @@ import org.springframework.web.client.RestClientException;
 @RequiredArgsConstructor
 public class CalendarCommandService {
 
-    private static final String TOKENS_DIR = "tokens";
+    private static final String DEFAULT_TOKENS_DIR = "tokens";
 
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final GoogleProperties googleProperties;
@@ -87,7 +87,7 @@ public class CalendarCommandService {
 
     private void saveRefreshToken(String email, String refreshToken) {
         try {
-            Path dir = Paths.get(TOKENS_DIR);
+            Path dir = tokenDirectory();
             if (!Files.exists(dir)) {
                 Files.createDirectories(dir);
             }
@@ -100,7 +100,7 @@ public class CalendarCommandService {
     }
 
     private String loadRefreshToken(String email) {
-        Path tokenFile = Paths.get(TOKENS_DIR, sanitize(email));
+        Path tokenFile = tokenDirectory().resolve(sanitize(email));
         if (!Files.exists(tokenFile)) {
             throw new AuthException(AuthErrorCode.CALENDAR_NOT_CONNECTED);
         }
@@ -114,6 +114,14 @@ public class CalendarCommandService {
 
     private String sanitize(String email) {
         return email.replaceAll("[^a-zA-Z0-9_-]", "_");
+    }
+
+    private Path tokenDirectory() {
+        String configuredDirectory = googleProperties.getTokenDirectory();
+        if (configuredDirectory == null || configuredDirectory.isBlank()) {
+            return Paths.get(DEFAULT_TOKENS_DIR);
+        }
+        return Paths.get(configuredDirectory);
     }
 
     private String refreshAccessToken(String refreshToken) {

--- a/src/main/resources/config/google.yaml
+++ b/src/main/resources/config/google.yaml
@@ -4,3 +4,4 @@ ajou:
     token-endpoint: https://oauth2.googleapis.com/token
     calendar-api-url: https://www.googleapis.com/calendar/v3/calendars/{calendarId}/events
     people-api-url: https://people.googleapis.com/v1/people/me?personFields=organizations
+    token-directory: ${CALENDAR_TOKEN_DIRECTORY:/app/tokens}


### PR DESCRIPTION
## 작업 내용

- Calendar refresh token 저장 경로를 `ajou.google.token-directory` 설정으로 분리했습니다.
- 운영 기본 저장 경로를 `/app/tokens`로 지정했습니다.
- `app` 컨테이너에 `calendar_tokens:/app/tokens` Docker named volume을 추가했습니다.

## 원인

`/api/event/calendar` 요청이 `AE-AUTH-CALENDAR-NOT-CONNECTED`로 실패했고, 서버 로그상 `CalendarCommandService.loadRefreshToken()`에서 refresh token 파일을 찾지 못해 실패했습니다.

기존 구조는 refresh token을 컨테이너 내부 상대 경로 `tokens/`에 저장했지만, `docker-compose.yml`의 `app` 서비스에 해당 경로 볼륨이 없어 컨테이너 재생성/재배포 시 캘린더 연동 정보가 유실될 수 있었습니다.

## 기대 효과

- `/api/users/connect-calendar` 성공 후 생성되는 refresh token 파일이 `/app/tokens`에 저장됩니다.
- `/app/tokens`는 `calendar_tokens` named volume에 마운트되어 컨테이너 재생성 이후에도 유지됩니다.
- 로컬/테스트 환경에서는 `CALENDAR_TOKEN_DIRECTORY`로 저장 경로를 바꿀 수 있습니다.

## 검증

- [x] `./gradlew compileJava`
- [x] `docker compose config`로 `calendar_tokens -> /app/tokens` 마운트 렌더링 확인
- [ ] `./gradlew test`

`./gradlew test`는 기존 테스트 컨텍스트 로딩 문제로 실패했습니다.
실패 사유는 Feign URL 설정 `URISyntaxException` 및 로컬 테스트 환경에서 Loki(`http://loki:3100`)에 연결할 수 없는 문제이며, 이번 변경 범위와 직접 관련된 컴파일/compose 설정 검증은 통과했습니다.

## 배포 후 확인 필요

1. 배포 후 `docker inspect ajouevent-app` 또는 `docker compose config`로 `/app/tokens` 마운트 확인
2. 프론트에서 캘린더 연동 플로우 실행
3. `docker exec ajouevent-app sh -lc 'ls -lah /app/tokens'`로 token 파일 생성 확인
4. `/api/event/calendar` 재시도

Closes #95
