### PR TITLE
[Fix] 소셜 로그인 시 캘린더 토큰 저장 #101

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/dto/auth/GoogleOauthResult.java
+++ b/src/main/java/com/example/ajouevent_be_v2/dto/auth/GoogleOauthResult.java
@@ -1,0 +1,7 @@
+package com.example.ajouevent_be_v2.dto.auth;
+
+public record GoogleOauthResult(
+    GoogleUserInfoResult userInfo,
+    String refreshToken
+) {
+}

--- a/src/main/java/com/example/ajouevent_be_v2/orchestrator/AuthOrchestrator.java
+++ b/src/main/java/com/example/ajouevent_be_v2/orchestrator/AuthOrchestrator.java
@@ -6,10 +6,11 @@ import com.example.ajouevent_be_v2.domain.member.Member;
 import com.example.ajouevent_be_v2.domain.member.Token;
 import com.example.ajouevent_be_v2.domain.topic.Topic;
 import com.example.ajouevent_be_v2.dto.auth.AuthTokenResult;
-import com.example.ajouevent_be_v2.dto.auth.GoogleUserInfoResult;
+import com.example.ajouevent_be_v2.dto.auth.GoogleOauthResult;
 import com.example.ajouevent_be_v2.dto.auth.LoginResponse;
 import com.example.ajouevent_be_v2.dto.auth.OauthRequest;
 import com.example.ajouevent_be_v2.dto.auth.TestLoginResponse;
+import com.example.ajouevent_be_v2.service.calendar.CalendarCommandService;
 import com.example.ajouevent_be_v2.dto.member.MemberLoginResult;
 import com.example.ajouevent_be_v2.service.auth.AuthService;
 import com.example.ajouevent_be_v2.service.auth.OauthService;
@@ -37,15 +38,22 @@ public class AuthOrchestrator {
     private final KeywordQueryService keywordQueryService;
     private final TokenService tokenService;
     private final DiscordMessageService discordMessageService;
+    private final CalendarCommandService calendarCommandService;
 
     public AuthTokenResult socialLogin(OauthRequest request) {
-        GoogleUserInfoResult userInfo = oauthService.getUserInfo(request);
-        MemberLoginResult memberResult = memberService.findOrCreateMember(userInfo);
+        GoogleOauthResult oauthResult = oauthService.getOauthResult(request);
+        MemberLoginResult memberResult = memberService.findOrCreateMember(oauthResult.userInfo());
         if (memberResult.isNewMember()) {
             sendNewMemberDiscordNotification(memberResult.member());
         }
         if (request.fcmToken() != null) {
             registerFcmToken(memberResult.member(), request.fcmToken());
+        }
+        if (oauthResult.refreshToken() != null) {
+            calendarCommandService.saveRefreshToken(
+                memberResult.member().getEmail(),
+                oauthResult.refreshToken()
+            );
         }
         return authService.issueTokens(memberResult.member(), memberResult.isNewMember());
     }

--- a/src/main/java/com/example/ajouevent_be_v2/service/auth/OauthService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/auth/OauthService.java
@@ -3,6 +3,7 @@ package com.example.ajouevent_be_v2.service.auth;
 import com.example.ajouevent_be_v2.common.exception.auth.AuthErrorCode;
 import com.example.ajouevent_be_v2.common.exception.auth.AuthException;
 import com.example.ajouevent_be_v2.config.properties.GoogleProperties;
+import com.example.ajouevent_be_v2.dto.auth.GoogleOauthResult;
 import com.example.ajouevent_be_v2.dto.auth.GooglePeopleResult;
 import com.example.ajouevent_be_v2.dto.auth.GoogleUserInfoResult;
 import com.example.ajouevent_be_v2.dto.auth.OauthRequest;
@@ -38,7 +39,7 @@ public class OauthService {
     private final DefaultOAuth2UserService userService = new DefaultOAuth2UserService();
     private final RestClient restClient = RestClient.create();
 
-    public GoogleUserInfoResult getUserInfo(OauthRequest request) {
+    public GoogleOauthResult getOauthResult(OauthRequest request) {
         ClientRegistration clientRegistration =
             clientRegistrationRepository.findByRegistrationId(googleProperties.getRegistrationId());
 
@@ -67,6 +68,9 @@ public class OauthService {
         try {
             var tokenResponse = tokenResponseClient.getTokenResponse(grantRequest);
             String accessToken = tokenResponse.getAccessToken().getTokenValue();
+            String refreshToken = tokenResponse.getRefreshToken() != null
+                ? tokenResponse.getRefreshToken().getTokenValue()
+                : null;
 
             OAuth2User oAuth2User = userService.loadUser(
                 new OAuth2UserRequest(clientRegistration, tokenResponse.getAccessToken())
@@ -74,10 +78,13 @@ public class OauthService {
 
             String department = fetchDepartmentFromPeopleApi(accessToken);
 
-            return new GoogleUserInfoResult(
-                oAuth2User.getAttribute("email"),
-                oAuth2User.getAttribute("name"),
-                department
+            return new GoogleOauthResult(
+                new GoogleUserInfoResult(
+                    oAuth2User.getAttribute("email"),
+                    oAuth2User.getAttribute("name"),
+                    department
+                ),
+                refreshToken
             );
         } catch (OAuth2AuthorizationException e) {
             log.warn("OAuth2 토큰 교환 실패: {}", e.getMessage());

--- a/src/main/java/com/example/ajouevent_be_v2/service/calendar/CalendarCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/calendar/CalendarCommandService.java
@@ -85,7 +85,7 @@ public class CalendarCommandService {
         postCalendarEvent(email, accessToken, request);
     }
 
-    private void saveRefreshToken(String email, String refreshToken) {
+    public void saveRefreshToken(String email, String refreshToken) {
         try {
             Path dir = tokenDirectory();
             if (!Files.exists(dir)) {
@@ -93,6 +93,7 @@ public class CalendarCommandService {
             }
             Path tokenFile = dir.resolve(sanitize(email));
             Files.writeString(tokenFile, refreshToken);
+            log.info("Google Calendar refresh token 저장 완료 - email: {}", email);
         } catch (IOException e) {
             log.error("캘린더 refresh token 저장 실패 - email: {}", email, e);
             throw new AuthException(AuthErrorCode.CALENDAR_NOT_CONNECTED);


### PR DESCRIPTION
## 🔗 관련 이슈

> #101

## 💡 작업 내용

- Google OAuth code 교환 결과에서 사용자 정보와 refresh token을 함께 반환하도록 변경했습니다.
- `/api/users/oauth` 소셜 로그인 처리 중 refresh token이 존재하면 캘린더 토큰 저장 로직을 호출하도록 연결했습니다.
- 기존 `/api/users/connect-calendar`에서만 쓰던 refresh token 저장 메서드를 로그인 플로우에서도 재사용할 수 있도록 공개했습니다.

## 📝 추가 설명(선택)

V1에서는 소셜 로그인 과정에서 `connectCalendar()`를 호출해 refresh token을 즉시 저장했습니다. V2는 `/api/users/connect-calendar` API가 분리되어 있었지만 프론트에서 호출하지 않고, Google authorization code는 1회용이라 로그인 이후 같은 code로 캘린더 연동을 다시 수행할 수 없습니다.

따라서 V1과 동일하게 로그인 시점에 refresh token을 저장하도록 맞췄습니다. 서버에는 이미 `/app/tokens` Docker volume이 마운트되어 있어 배포 후 재로그인하면 사용자별 token 파일이 영속 저장됩니다.

## 📚 참고 자료(선택)

검증:

```text
./gradlew spotlessApply
./gradlew compileJava
git diff --check
```
