### PR TITLE
[Chore] schema 업데이트 및 index 재구성 #103

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/config/IndexInitializer.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/IndexInitializer.java
@@ -1,0 +1,73 @@
+package com.example.ajouevent_be_v2.config;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(1)
+public class IndexInitializer implements ApplicationRunner {
+
+    private static final int MYSQL_ER_DUP_KEYNAME = 1061;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        ClassPathResource resource = new ClassPathResource("create-indexes.sql");
+        String sql;
+        try (InputStream is = resource.getInputStream()) {
+            sql = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        int created = 0;
+        int skipped = 0;
+        for (String segment : sql.split(";")) {
+            String statement = stripComments(segment).trim();
+            if (statement.isEmpty()) {
+                continue;
+            }
+            try {
+                jdbcTemplate.execute(statement);
+                created++;
+            } catch (DataAccessException e) {
+                if (isDuplicateKeyName(e)) {
+                    skipped++;
+                } else {
+                    throw e;
+                }
+            }
+        }
+        log.info("Index initialization complete — created: {}, already existed: {}", created, skipped);
+    }
+
+    private String stripComments(String segment) {
+        return Arrays.stream(segment.split("\n"))
+            .filter(line -> !line.trim().startsWith("--"))
+            .collect(Collectors.joining("\n"));
+    }
+
+    private boolean isDuplicateKeyName(Throwable e) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof SQLException sqlEx && sqlEx.getErrorCode() == MYSQL_ER_DUP_KEYNAME) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/resources/create-indexes.sql
+++ b/src/main/resources/create-indexes.sql
@@ -1,0 +1,106 @@
+-- =============================================
+-- AjouEvent V2 — 인덱스 생성
+-- IndexInitializer(ApplicationRunner)가 서비스 시작 시 실행
+-- 이미 존재하는 인덱스는 error 1061을 잡아 건너뜀 (재시작 안전)
+-- =============================================
+
+-- members
+-- findByEmail
+ALTER TABLE members ADD UNIQUE KEY uq_members_email (email);
+
+-- tokens
+-- findByTokenValue... / batchSoftDeleteByTokenValues
+ALTER TABLE tokens ADD UNIQUE KEY uq_tokens_token_value (token_value);
+
+-- topics
+-- uq_topics_type: 타입 컬럼 유일성 보장
+-- findFirstByDepartment → department 필터
+-- findByKoreanTopic → korean_topic 필터
+ALTER TABLE topics ADD UNIQUE KEY uq_topics_type (type);
+ALTER TABLE topics ADD INDEX idx_topics_department (department);
+ALTER TABLE topics ADD INDEX idx_topics_korean_topic (korean_topic);
+
+-- topic_members
+-- existsByTopicAndMember / findByMemberAndTopic / deleteByTopicAndMember
+--   → uq_topic_members (member_id, topic_id)  — unique + leading prefix (member_id) 커버
+-- existsByMemberAndIsReadFalse
+--   → idx_topic_members_member_isread (member_id, is_read)
+-- findByTopicWithMemberAndReceiveNotificationTrue (push 발송 라우팅 핵심 쿼리)
+--   → idx_topic_members_topic_notification (topic_id, receive_notification)
+ALTER TABLE topic_members ADD UNIQUE KEY uq_topic_members (member_id, topic_id);
+ALTER TABLE topic_members ADD INDEX idx_topic_members_member_isread (member_id, is_read);
+ALTER TABLE topic_members ADD INDEX idx_topic_members_topic_notification (topic_id, receive_notification);
+
+-- topic_tokens
+-- deleteByTopicAndTokenValues → (topic_id, token_value)
+-- deleteAllByTokenValues → token_value 단독
+ALTER TABLE topic_tokens ADD INDEX idx_topic_tokens_topic_token (topic_id, token_value);
+ALTER TABLE topic_tokens ADD INDEX idx_topic_tokens_token_value (token_value);
+
+-- keywords
+-- findByEncodedKeyword → encoded_keyword 단독
+-- findBySearchKeyword → search_keyword 단독
+-- findByTopic → topic_id 필터
+ALTER TABLE keywords ADD UNIQUE KEY uq_keywords_encoded_keyword (encoded_keyword);
+ALTER TABLE keywords ADD INDEX idx_keywords_search_keyword (search_keyword);
+ALTER TABLE keywords ADD INDEX idx_keywords_topic_id (topic_id);
+
+-- keyword_members
+-- existsByKeywordAndMember / findByKeywordAndMemberAndIsReadFalse / deleteByKeywordAndMember
+--   → uq_keyword_members (member_id, keyword_id)  — unique + leading prefix 커버
+-- existsByMemberAndIsReadFalse
+--   → idx_keyword_members_member_isread (member_id, is_read)
+-- findByKeywordWithMember
+--   → idx_keyword_members_keyword_id (keyword_id)
+ALTER TABLE keyword_members ADD UNIQUE KEY uq_keyword_members (member_id, keyword_id);
+ALTER TABLE keyword_members ADD INDEX idx_keyword_members_member_isread (member_id, is_read);
+ALTER TABLE keyword_members ADD INDEX idx_keyword_members_keyword_id (keyword_id);
+
+-- keyword_tokens
+-- deleteByKeywordAndTokenValues → (keyword_id, token_value)
+-- deleteAllByTokenValues / findKeywordTokensWithKeyword → token_value 단독
+ALTER TABLE keyword_tokens ADD INDEX idx_keyword_tokens_keyword_token (keyword_id, token_value);
+ALTER TABLE keyword_tokens ADD INDEX idx_keyword_tokens_token_value (token_value);
+
+-- club_events
+-- findByTypeIn / findByTypeAndTitleContaining / findByTypeInAndTitleContaining
+-- findByTypeAndAnyKeyword / findTop10ByType
+--   → idx_club_events_type_createdat (type, created_at)  — type 필터 후 created_at DESC 정렬 커버
+-- findTop10ByCreatedAtBetween (주간 트렌딩)
+--   → idx_club_events_createdat_viewcount (created_at, view_count)
+ALTER TABLE club_events ADD INDEX idx_club_events_type_createdat (type, created_at);
+ALTER TABLE club_events ADD INDEX idx_club_events_createdat_viewcount (created_at, view_count);
+
+-- event_likes
+-- existsByMemberAndClubEvent / findByClubEventAndMember / findByMemberWithClubEvent
+--   → uq_event_likes (member_id, club_event_id)  — unique + leading prefix (member_id) 커버
+ALTER TABLE event_likes ADD UNIQUE KEY uq_event_likes (member_id, club_event_id);
+
+-- push_clusters
+-- findAllByJobStatus
+ALTER TABLE push_clusters ADD INDEX idx_push_clusters_job_status (job_status);
+
+-- push_cluster_tokens
+-- findAllByPushClusterWithMember → push_cluster_id 필터
+-- findRecoverableTokens — OR 조건 3개를 각 인덱스로 개별 커버
+--   PENDING      AND request_time   < ?  → (job_status, request_time)
+--   IN_PROGRESS  AND processed_time < ?  → (job_status, processed_time)
+--   RETRY_PENDING AND retry_after <= ? AND retry_count <= ?
+--                                        → (job_status, retry_after, retry_count)
+ALTER TABLE push_cluster_tokens ADD INDEX idx_pct_push_cluster_id (push_cluster_id);
+ALTER TABLE push_cluster_tokens ADD INDEX idx_pct_status_request (job_status, request_time);
+ALTER TABLE push_cluster_tokens ADD INDEX idx_pct_status_processed (job_status, processed_time);
+ALTER TABLE push_cluster_tokens ADD INDEX idx_pct_status_retry (job_status, retry_after, retry_count);
+
+-- push_notifications
+-- findByMemberAndNotificationType / findTopicNotificationsByMemberWithTopic
+-- findKeywordNotificationsByMemberWithTopicAndKeyword
+--   → idx_pn_member_type_notified (member_id, notification_type, notified_at)
+--     notification_type 필터 후 notified_at DESC 정렬 커버
+-- countByMemberAndIsReadFalse / updateAllUnreadByMember
+--   → idx_pn_member_isread (member_id, is_read)
+-- findFirstByPushClusterId
+--   → idx_pn_push_cluster_id (push_cluster_id)
+ALTER TABLE push_notifications ADD INDEX idx_pn_member_type_notified (member_id, notification_type, notified_at);
+ALTER TABLE push_notifications ADD INDEX idx_pn_member_isread (member_id, is_read);
+ALTER TABLE push_notifications ADD INDEX idx_pn_push_cluster_id (push_cluster_id);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
 -- =============================================
 -- AjouEvent V2 DDL
+-- 인덱스/유니크 키는 create-indexes.sql 에서 관리
 -- =============================================
 
 -- members
@@ -9,8 +10,7 @@ CREATE TABLE IF NOT EXISTS members (
     name   VARCHAR(255),
     major  VARCHAR(255),
     role   VARCHAR(20)  NOT NULL DEFAULT 'USER',
-    PRIMARY KEY (id),
-    UNIQUE KEY uq_members_email (email)
+    PRIMARY KEY (id)
 );
 
 -- tokens
@@ -21,13 +21,10 @@ CREATE TABLE IF NOT EXISTS tokens (
     member_id       BIGINT,
     is_deleted      TINYINT(1)   NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_tokens_token_value (token_value),
     CONSTRAINT fk_tokens_member FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
 -- topics
--- findFirstByDepartment        → idx_topics_department
--- findByKoreanTopic            → idx_topics_korean_topic
 CREATE TABLE IF NOT EXISTS topics (
     id             BIGINT       NOT NULL AUTO_INCREMENT,
     department     VARCHAR(255),
@@ -35,19 +32,10 @@ CREATE TABLE IF NOT EXISTS topics (
     classification VARCHAR(255),
     korean_topic   VARCHAR(255),
     korean_order   BIGINT,
-    PRIMARY KEY (id),
-    UNIQUE KEY uq_topics_type (type),
-    INDEX idx_topics_department  (department),
-    INDEX idx_topics_korean_topic (korean_topic)
+    PRIMARY KEY (id)
 );
 
 -- topic_members
--- existsByTopicAndMember / findByMemberAndTopic / deleteByTopicAndMember
---   → uq_topic_members (member_id, topic_id)  — unique + leading prefix (member_id) 커버
--- existsByMemberAndIsReadFalse
---   → idx_topic_members_member_isread (member_id, is_read)
--- findByTopicWithMemberAndReceiveNotificationTrue (push 발송 라우팅 핵심 쿼리)
---   → idx_topic_members_topic_notification (topic_id, receive_notification)
 CREATE TABLE IF NOT EXISTS topic_members (
     id                   BIGINT     NOT NULL AUTO_INCREMENT,
     topic_id             BIGINT,
@@ -56,30 +44,20 @@ CREATE TABLE IF NOT EXISTS topic_members (
     last_read_at         DATETIME   NOT NULL,
     receive_notification TINYINT(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_topic_members (member_id, topic_id),
-    INDEX idx_topic_members_member_isread      (member_id, is_read),
-    INDEX idx_topic_members_topic_notification (topic_id, receive_notification),
     CONSTRAINT fk_topic_members_topic  FOREIGN KEY (topic_id)  REFERENCES topics  (id),
     CONSTRAINT fk_topic_members_member FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
 -- topic_tokens
--- deleteByTopicAndTokenValues  → idx_topic_tokens_topic_token (topic_id, token_value)
--- deleteAllByTokenValues       → idx_topic_tokens_token_value (token_value)
 CREATE TABLE IF NOT EXISTS topic_tokens (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     topic_id    BIGINT,
     token_value VARCHAR(255),
     PRIMARY KEY (id),
-    INDEX idx_topic_tokens_topic_token (topic_id, token_value),
-    INDEX idx_topic_tokens_token_value (token_value),
     CONSTRAINT fk_topic_tokens_topic FOREIGN KEY (topic_id) REFERENCES topics (id)
 );
 
 -- keywords
--- findByEncodedKeyword         → uq_keywords_encoded_keyword (encoded_keyword)
--- findBySearchKeyword          → idx_keywords_search_keyword (search_keyword)
--- findByTopic                  → idx_keywords_topic_id (topic_id)
 CREATE TABLE IF NOT EXISTS keywords (
     id               BIGINT       NOT NULL AUTO_INCREMENT,
     encoded_keyword  VARCHAR(255),
@@ -87,19 +65,10 @@ CREATE TABLE IF NOT EXISTS keywords (
     search_keyword   VARCHAR(255),
     topic_id         BIGINT,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_keywords_encoded_keyword (encoded_keyword),
-    INDEX idx_keywords_search_keyword (search_keyword),
-    INDEX idx_keywords_topic_id       (topic_id),
     CONSTRAINT fk_keywords_topic FOREIGN KEY (topic_id) REFERENCES topics (id)
 );
 
 -- keyword_members
--- existsByKeywordAndMember / findByKeywordAndMemberAndIsReadFalse / deleteByKeywordAndMember
---   → uq_keyword_members (member_id, keyword_id)  — unique + leading prefix 커버
--- existsByMemberAndIsReadFalse
---   → idx_keyword_members_member_isread (member_id, is_read)
--- findByKeywordWithMember
---   → idx_keyword_members_keyword_id (keyword_id)
 CREATE TABLE IF NOT EXISTS keyword_members (
     id           BIGINT     NOT NULL AUTO_INCREMENT,
     keyword_id   BIGINT,
@@ -107,34 +76,20 @@ CREATE TABLE IF NOT EXISTS keyword_members (
     is_read      TINYINT(1) NOT NULL DEFAULT 0,
     last_read_at DATETIME   NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_keyword_members (member_id, keyword_id),
-    INDEX idx_keyword_members_member_isread (member_id, is_read),
-    INDEX idx_keyword_members_keyword_id    (keyword_id),
     CONSTRAINT fk_keyword_members_keyword FOREIGN KEY (keyword_id) REFERENCES keywords (id),
     CONSTRAINT fk_keyword_members_member  FOREIGN KEY (member_id)  REFERENCES members  (id)
 );
 
 -- keyword_tokens
--- deleteByKeywordAndTokenValues  → idx_keyword_tokens_keyword_token (keyword_id, token_value)
--- deleteAllByTokenValues / findKeywordTokensWithKeyword
---   → idx_keyword_tokens_token_value (token_value)
 CREATE TABLE IF NOT EXISTS keyword_tokens (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     keyword_id  BIGINT,
     token_value VARCHAR(255),
     PRIMARY KEY (id),
-    INDEX idx_keyword_tokens_keyword_token (keyword_id, token_value),
-    INDEX idx_keyword_tokens_token_value   (token_value),
     CONSTRAINT fk_keyword_tokens_keyword FOREIGN KEY (keyword_id) REFERENCES keywords (id)
 );
 
 -- club_events
--- findByTypeIn / findByTypeInAndTitleContaining / findTop10ByTypeOrderByCreatedAtDesc
--- findByTypeAndAnyKeyword
---   → idx_club_events_type_createdat (type, created_at)
---     type 필터 후 created_at DESC 정렬까지 인덱스 커버
--- findTop10ByCreatedAtBetweenOrderByViewCountDesc (주간 트렌딩)
---   → idx_club_events_createdat_viewcount (created_at, view_count)
 CREATE TABLE IF NOT EXISTS club_events (
     event_id         BIGINT        NOT NULL AUTO_INCREMENT,
     title            VARCHAR(255),
@@ -147,9 +102,7 @@ CREATE TABLE IF NOT EXISTS club_events (
     likes_count      BIGINT        NOT NULL DEFAULT 0,
     view_count       BIGINT        NOT NULL DEFAULT 0,
     type             VARCHAR(100),
-    PRIMARY KEY (event_id),
-    INDEX idx_club_events_type_createdat     (type, created_at),
-    INDEX idx_club_events_createdat_viewcount (created_at, view_count)
+    PRIMARY KEY (event_id)
 );
 
 -- club_event_images
@@ -173,20 +126,16 @@ CREATE TABLE IF NOT EXISTS event_banners (
 );
 
 -- event_likes
--- existsByMemberAndClubEvent / findByClubEventAndMember / deleteByMemberAndClubEvent
---   → uq_event_likes (member_id, club_event_id) — unique + leading prefix(member_id) 커버
 CREATE TABLE IF NOT EXISTS event_likes (
     event_like_id BIGINT NOT NULL AUTO_INCREMENT,
     club_event_id BIGINT,
     member_id     BIGINT,
     PRIMARY KEY (event_like_id),
-    UNIQUE KEY uq_event_likes (member_id, club_event_id),
     CONSTRAINT fk_event_likes_club_event FOREIGN KEY (club_event_id) REFERENCES club_events (event_id),
     CONSTRAINT fk_event_likes_member     FOREIGN KEY (member_id)     REFERENCES members    (id)
 );
 
 -- push_clusters
--- findAllByJobStatus            → idx_push_clusters_job_status (job_status)
 CREATE TABLE IF NOT EXISTS push_clusters (
     id                  BIGINT       NOT NULL AUTO_INCREMENT,
     club_event_id       BIGINT,
@@ -204,18 +153,10 @@ CREATE TABLE IF NOT EXISTS push_clusters (
     retry_success_count INT          NOT NULL DEFAULT 0,
     retry_fail_count    INT          NOT NULL DEFAULT 0,
     PRIMARY KEY (id),
-    INDEX idx_push_clusters_job_status (job_status),
     CONSTRAINT fk_push_clusters_club_event FOREIGN KEY (club_event_id) REFERENCES club_events (event_id)
 );
 
 -- push_cluster_tokens
--- findAllByPushClusterWithMember
---   → idx_pct_push_cluster_id (push_cluster_id)
--- findRecoverableTokens — OR 조건 3개를 각 인덱스로 개별 커버
---   PENDING      AND request_time   < ?  → idx_pct_status_request   (job_status, request_time)
---   IN_PROGRESS  AND processed_time < ?  → idx_pct_status_processed (job_status, processed_time)
---   RETRY_PENDING AND retry_after <= ? AND retry_count <= ?
---                                        → idx_pct_status_retry     (job_status, retry_after, retry_count)
 CREATE TABLE IF NOT EXISTS push_cluster_tokens (
     id              BIGINT       NOT NULL AUTO_INCREMENT,
     push_cluster_id BIGINT       NOT NULL,
@@ -227,23 +168,11 @@ CREATE TABLE IF NOT EXISTS push_cluster_tokens (
     retry_count     INT          NOT NULL DEFAULT 0,
     retry_after     DATETIME,
     PRIMARY KEY (id),
-    INDEX idx_pct_push_cluster_id    (push_cluster_id),
-    INDEX idx_pct_status_request     (job_status, request_time),
-    INDEX idx_pct_status_processed   (job_status, processed_time),
-    INDEX idx_pct_status_retry       (job_status, retry_after, retry_count),
     CONSTRAINT fk_push_cluster_tokens_push_cluster FOREIGN KEY (push_cluster_id) REFERENCES push_clusters (id),
     CONSTRAINT fk_push_cluster_tokens_member       FOREIGN KEY (member_id)       REFERENCES members       (id)
 );
 
 -- push_notifications
--- findByMemberAndNotificationType / findTopicNotificationsByMemberWithTopic
--- findKeywordNotificationsByMemberWithTopicAndKeyword
---   → idx_pn_member_type_notified (member_id, notification_type, notified_at)
---     notification_type = 'TOPIC'/'KEYWORD' 필터 후 notified_at DESC 정렬 커버
--- countByMemberAndIsReadFalse / updateAllUnreadByMember
---   → idx_pn_member_isread (member_id, is_read)
--- findFirstByPushClusterId
---   → idx_pn_push_cluster_id (push_cluster_id)
 CREATE TABLE IF NOT EXISTS push_notifications (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
     push_cluster_id   BIGINT       NOT NULL,
@@ -259,9 +188,6 @@ CREATE TABLE IF NOT EXISTS push_notifications (
     clicked_at        DATETIME,
     notified_at       DATETIME,
     PRIMARY KEY (id),
-    INDEX idx_pn_member_type_notified (member_id, notification_type, notified_at),
-    INDEX idx_pn_member_isread        (member_id, is_read),
-    INDEX idx_pn_push_cluster_id      (push_cluster_id),
     CONSTRAINT fk_push_notifications_push_cluster FOREIGN KEY (push_cluster_id) REFERENCES push_clusters (id),
     CONSTRAINT fk_push_notifications_topic        FOREIGN KEY (topic_id)        REFERENCES topics        (id),
     CONSTRAINT fk_push_notifications_keyword      FOREIGN KEY (keyword_id)      REFERENCES keywords      (id),


### PR DESCRIPTION
## 🔗 관련 이슈

> #103 

## 💡 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

## 📝 추가 설명(선택)

- `schema.sql`
  - INDEX/UNIQUE KEY 모두 제거
  - PRIMARY KEY + FOREIGN KEY만 남김
- `create-indexes.sql (신규)`
  - 전체 인덱스를 테이블별 ALTER TABLE ... ADD INDEX/UNIQUE KEY 한 줄씩 구성.
  - 각 인덱스마다 어떤 쿼리 메서드가 사용하는지 주석 포함
- `IndexInitializer.java (신규)`
  - @Order(1) ApplicationRunner로 서비스 시작 시 실행
  - 동작 방식:
    1.  첫 기동 (신규 DB): 인덱스 없으므로 전부 생성
    2.  재시작 (기존 DB): 1061 에러 catch → 전부 skip, 정상 기동
    3.  로컬 (ddl-auto: create): Hibernate가 테이블 재생성 → 인덱스 없어지고 → Initializer가 전부 재생성
