### PR TITLE
[Fix] refreshToken 쿠키 누락 예외 처리 #105

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.example.ajouevent_be_v2.common.exception;
 
 import com.example.ajouevent_be_v2.common.exception.common.CommonErrorCode;
+import com.example.ajouevent_be_v2.common.exception.auth.AuthErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -32,6 +34,13 @@ public class GlobalExceptionHandler {
         log.error("[IllegalArgumentException] {}", e.getMessage(), e);
         return ResponseEntity.status(CommonErrorCode.VALIDATION_ERROR.getStatus())
                 .body(new ErrorResponse(CommonErrorCode.VALIDATION_ERROR.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestCookie(MissingRequestCookieException e) {
+        log.warn("[MissingRequestCookieException] required cookie is missing - {}", e.getCookieName());
+        return ResponseEntity.status(AuthErrorCode.UNAUTHORIZED.getStatus())
+                .body(ErrorResponse.of(AuthErrorCode.UNAUTHORIZED));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/ajouevent_be_v2/config/SecurityConfig.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/SecurityConfig.java
@@ -46,7 +46,11 @@ public class SecurityConfig implements WebMvcConfigurer {
             "/api/users/oauth", "/api/users/reissue-token", "/api/users/logout",
             "/api/topic/all",
             "/api/webhook/crawling",
-            "/api/event/banner"
+            "/api/event/banner",
+            "/api/event/popular",
+            "/api/event/subscribed",
+            "/api/event/detail/**",
+            "/api/event/{type}"
     };
 
     private static final String[] LOCAL_AUTH_WHITELIST = {

--- a/src/test/java/com/example/ajouevent_be_v2/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/ajouevent_be_v2/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,23 @@
+package com.example.ajouevent_be_v2.common.exception;
+
+import com.example.ajouevent_be_v2.common.exception.auth.AuthErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestCookieException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+    @Test
+    void handleMissingRequestCookieReturnsUnauthorized() {
+        MissingRequestCookieException exception = new MissingRequestCookieException("refreshToken", null);
+
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMissingRequestCookie(exception);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(AuthErrorCode.UNAUTHORIZED.getStatus());
+        assertThat(response.getBody()).isEqualTo(ErrorResponse.of(AuthErrorCode.UNAUTHORIZED));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#105

## 💡 작업 내용

- `refreshToken` 쿠키가 없는 `/api/users/reissue-token` 요청에서 발생하는 `MissingRequestCookieException`을 별도로 처리했습니다.
- 해당 상황을 서버 내부 오류가 아닌 `401 Unauthorized` / `AE-AUTH-UNAUTHORIZED` 응답으로 반환하도록 변경했습니다.
- 쿠키 누락 예외 처리 결과를 검증하는 `GlobalExceptionHandlerTest`를 추가했습니다.
- `@AuthOptional`이 적용된 공개 이벤트 조회 API가 Spring Security 인증 단계에서 차단되지 않도록 화이트리스트에 추가했습니다.

## 📝 추가 설명(선택)

운영 환경에서 로그인하지 않은 사용자, 쿠키가 삭제된 사용자, refreshToken 만료 이후 앱 초기화 요청 등은 `refreshToken` 쿠키 없이 토큰 재발급을 호출할 수 있습니다.
이 상황은 서버 장애가 아니라 인증 실패이므로 `Unhandled Server Error`로 로깅되지 않도록 정리했습니다.

또한 `@AuthOptional`은 컨트롤러 파라미터 처리 단계의 선택 인증이며, Spring Security 인증 필터를 자동으로 우회하지 않습니다.
따라서 비로그인 사용자도 접근 가능한 이벤트 조회 API는 `AUTH_WHITELIST`에 포함해야 합니다.

추가한 공개 이벤트 조회 API:

```text
/api/event/popular
/api/event/subscribed
/api/event/detail/**
/api/event/{type}
```

화이트리스트에 추가하지 않은 인증 필수 API:

```text
/api/event/liked
/api/event/like/{eventId}
/api/event/calendar
/api/event/getSubscribedPostsByKeyword
/api/event/getSubscribedPostsByKeyword/{keyword}
```

검증 결과:

```text
./gradlew spotlessCheck compileJava
BUILD SUCCESSFUL
```

```text
./gradlew spotlessApply test --tests 'com.example.ajouevent_be_v2.common.exception.GlobalExceptionHandlerTest'
BUILD SUCCESSFUL
```

전체 테스트 참고:

```text
./gradlew spotlessApply test
```

위 명령은 기존 `AjouEventBeV2ApplicationTests.contextLoads()`에서 Feign URL 환경값 문제로 실패했습니다.
이번 변경 대상인 예외 핸들러 단위 테스트는 별도로 통과했습니다.

## 📚 참고 자료(선택)

운영 로그에서 확인된 기존 증상:

```text
[Exception] Unhandled Server Error - Required cookie 'refreshToken' for method parameter type String is not present
org.springframework.web.bind.MissingRequestCookieException: Required cookie 'refreshToken' for method parameter type String is not present
```
