### PR TITLE
[Fix] 알림 목록 조회 시 isRead 항상 true 반환 문제 및 디스코드 채널 분리 #107

### DIFF
--- a/src/main/java/com/example/ajouevent_be_v2/common/discord/DiscordMessageService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/common/discord/DiscordMessageService.java
@@ -3,6 +3,7 @@ package com.example.ajouevent_be_v2.common.discord;
 import com.example.ajouevent_be_v2.common.exception.discord.DiscordErrorCode;
 import com.example.ajouevent_be_v2.common.exception.discord.DiscordException;
 import com.example.ajouevent_be_v2.config.DiscordFeignClient;
+import com.example.ajouevent_be_v2.config.DiscordMemberFeignClient;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,12 +15,22 @@ import org.springframework.stereotype.Service;
 public class DiscordMessageService {
 
     private final DiscordFeignClient discordFeignClient;
+    private final DiscordMemberFeignClient discordMemberFeignClient;
 
-    public void sendMessage(String message) {
+    public void sendErrorMessage(String message) {
         try {
             discordFeignClient.sendMessage(new DiscordMessage(message));
         } catch (FeignException e) {
-            log.error("Discord webhook 전송 실패: {}", e.getMessage(), e);
+            log.error("Discord error webhook 전송 실패: {}", e.getMessage(), e);
+            throw new DiscordException(DiscordErrorCode.WEBHOOK_FAILED, e);
+        }
+    }
+
+    public void sendMemberMessage(String message) {
+        try {
+            discordMemberFeignClient.sendMessage(new DiscordMessage(message));
+        } catch (FeignException e) {
+            log.error("Discord member webhook 전송 실패: {}", e.getMessage(), e);
             throw new DiscordException(DiscordErrorCode.WEBHOOK_FAILED, e);
         }
     }

--- a/src/main/java/com/example/ajouevent_be_v2/config/DiscordMemberFeignClient.java
+++ b/src/main/java/com/example/ajouevent_be_v2/config/DiscordMemberFeignClient.java
@@ -6,8 +6,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "${ajou.discord.error.name}", url = "${ajou.discord.error.webhook-url}")
-public interface DiscordFeignClient {
+@FeignClient(name = "${ajou.discord.member.name}", url = "${ajou.discord.member.webhook-url}")
+public interface DiscordMemberFeignClient {
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     void sendMessage(@RequestBody DiscordMessage discordMessage);

--- a/src/main/java/com/example/ajouevent_be_v2/orchestrator/AuthOrchestrator.java
+++ b/src/main/java/com/example/ajouevent_be_v2/orchestrator/AuthOrchestrator.java
@@ -90,7 +90,7 @@ public class AuthOrchestrator {
                 member.getName(),
                 member.getMajor() != null ? member.getMajor() : "미입력"
             );
-            discordMessageService.sendMessage(message);
+            discordMessageService.sendMemberMessage(message);
         } catch (Exception e) {
             log.warn("Discord 신규 회원 알림 전송 실패 - email: {}", member.getEmail(), e);
         }

--- a/src/main/java/com/example/ajouevent_be_v2/orchestrator/NotificationOrchestrator.java
+++ b/src/main/java/com/example/ajouevent_be_v2/orchestrator/NotificationOrchestrator.java
@@ -24,13 +24,11 @@ public class NotificationOrchestrator {
 
     public SliceResponse<TopicNotificationResponse> getTopicNotifications(Member member, Pageable pageable) {
         SliceResult<PushNotification> sliceResult = notificationQueryService.getTopicNotifications(member, pageable);
-        notificationCommandService.markPageNotificationsAsRead(sliceResult.result());
         return SliceResponse.from(sliceResult, TopicNotificationResponse::from);
     }
 
     public SliceResponse<KeywordNotificationResponse> getKeywordNotifications(Member member, Pageable pageable) {
         SliceResult<PushNotification> sliceResult = notificationQueryService.getKeywordNotifications(member, pageable);
-        notificationCommandService.markPageNotificationsAsRead(sliceResult.result());
         return SliceResponse.from(sliceResult, KeywordNotificationResponse::from);
     }
 

--- a/src/main/java/com/example/ajouevent_be_v2/repository/adapter/notification/PushNotificationJpaRepositoryAdapter.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/adapter/notification/PushNotificationJpaRepositoryAdapter.java
@@ -54,10 +54,6 @@ public interface PushNotificationJpaRepositoryAdapter extends JpaRepository<Push
     void updateReadStatusByIds(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE PushNotification p SET p.isRead = true, p.clickedAt = :now WHERE p.id IN :ids AND p.isRead = false")
-    void updateReadStatusByIdsWhereUnread(@Param("ids") List<Long> ids, @Param("now") LocalDateTime now);
-
-    @Modifying(clearAutomatically = true)
     @Query("UPDATE PushNotification p SET p.isRead = true, p.clickedAt = :now WHERE p.member = :member AND p.isRead = false")
     void updateAllUnreadByMember(@Param("member") Member member, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/ajouevent_be_v2/repository/port/notification/PushNotificationRepositoryPort.java
+++ b/src/main/java/com/example/ajouevent_be_v2/repository/port/notification/PushNotificationRepositoryPort.java
@@ -63,10 +63,6 @@ public class PushNotificationRepositoryPort {
         pushNotificationJpaRepositoryAdapter.updateReadStatusByIds(ids, now);
     }
 
-    public void updateReadStatusByIdsWhereUnread(List<Long> ids, LocalDateTime now) {
-        pushNotificationJpaRepositoryAdapter.updateReadStatusByIdsWhereUnread(ids, now);
-    }
-
     public PushNotification save(PushNotification pushNotification) {
         return pushNotificationJpaRepositoryAdapter.save(pushNotification);
     }

--- a/src/main/java/com/example/ajouevent_be_v2/service/notification/NotificationCommandService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/notification/NotificationCommandService.java
@@ -36,17 +36,6 @@ public class NotificationCommandService {
     }
 
     @Transactional
-    public void markPageNotificationsAsRead(List<PushNotification> pageNotifications) {
-        if (pageNotifications.isEmpty()) {
-            return;
-        }
-        List<Long> ids = pageNotifications.stream()
-            .map(PushNotification::getId)
-            .toList();
-        pushNotificationRepositoryPort.updateReadStatusByIdsWhereUnread(ids, LocalDateTime.now());
-    }
-
-    @Transactional
     public void markAllAsReadByMember(Member member) {
         pushNotificationRepositoryPort.updateAllUnreadByMember(member, LocalDateTime.now());
     }

--- a/src/main/java/com/example/ajouevent_be_v2/service/webhook/FcmPushResultService.java
+++ b/src/main/java/com/example/ajouevent_be_v2/service/webhook/FcmPushResultService.java
@@ -203,7 +203,7 @@ public class FcmPushResultService {
             case SENDER_ID_MISMATCH:
                 // Firebase 프로젝트 Sender ID 불일치 — 서버 설정 오류. 운영자 확인 필요
                 token.markAsPermanentFail();
-                discordMessageService.sendMessage(
+                discordMessageService.sendErrorMessage(
                     String.format("[FCM SENDER_ID_MISMATCH] pushClusterId=%d, token=%s",
                         token.getPushCluster().getId(), token.getTokenValue()));
                 return 1;

--- a/src/main/resources/config/discord.yaml
+++ b/src/main/resources/config/discord.yaml
@@ -1,4 +1,8 @@
 ajou:
   discord:
-    name: ajouevent
-    webhook-url: ${DISCORD_WEBHOOK_URL}
+    error:
+      name: ajouevent-discord-error
+      webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
+    member:
+      name: ajouevent-discord-member
+      webhook-url: ${DISCORD_MEMBER_WEBHOOK_URL}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #107

## ✅ 원인

> 알림 목록 조회(`GET /api/notification/topic`, `GET /api/notification/keyword`) 시 `isRead` 필드가 항상 `true`로 반환되는 문제.

- `NotificationOrchestrator`에서 알림 목록을 조회한 직후 해당 알림들을 일괄 읽음 처리 하는 문제
  - `markPageNotificationsAsRead`
- 최초 조회에서는 in-memory 엔티티 상태(bulk update 이전 값)로 DTO가 생성되어 올바르게 반환되지만,
- 이후 동일 알림을 다시 조회하면 DB에서 이미 `is_read = true`로 저장된 상태로 조회되어 항상 `true` 반환

## 📝 추가 설명(선택)

### 읽음 처리 시점 변경 작업

| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| `GET /api/notification/topic` | 조회 시 자동 읽음 처리 | 읽음 처리 없음 |
| `GET /api/notification/keyword` | 조회 시 자동 읽음 처리 | 읽음 처리 없음 |
| `POST /api/notification/click` | 단건 읽음 처리 | 단건 읽음 처리 (유지) |

## 📢 Discord 웹훅을 신규 회원용과 에러용으로 분리

- Discord 웹훅을 신규 회원용과 에러용으로 분리
- 배포 환경에 DISCORD_ERROR_WEBHOOK_URL과 DISCORD_MEMBER_WEBHOOK_URL 환경변수를 추가 필요.
  - DISCORD_ERROR_WEBHOOK_URL - (에러 채널)
  - DISCORD_MEMBER_WEBHOOK_URL - (신규 회원 채널)