### PR TITLE
[Feat] 크롤링 서비스 모니터링 환경 통합 #109

### DIFF
--- a/monitoring/grafana/dashboards/ajouevent.json
+++ b/monitoring/grafana/dashboards/ajouevent.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "AjouEvent 통합 모니터링 — JVM · HTTP · DB · ThreadPool · FCM · Docker",
+  "description": "AjouEvent 통합 모니터링 — JVM · HTTP · DB · ThreadPool · FCM · Docker · 크롤링",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -611,7 +611,7 @@
       "id": 71,
       "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(container_cpu_usage_seconds_total{job=\"cadvisor\",id=~\"/docker/.+\"}[1m])", "legendFormat": "{{id}}", "refId": "A"}
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(container_cpu_usage_seconds_total{job=\"cadvisor\",name!=\"\"}[1m])", "legendFormat": "{{name}}", "refId": "A"}
       ],
       "title": "컨테이너 CPU 사용률",
       "type": "timeseries"
@@ -632,8 +632,8 @@
       "id": 72,
       "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_usage_bytes{job=\"cadvisor\",id=~\"/docker/.+\"}", "legendFormat": "{{id}} Usage", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_working_set_bytes{job=\"cadvisor\",id=~\"/docker/.+\"}", "legendFormat": "{{id}} Working Set", "refId": "B"}
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_usage_bytes{job=\"cadvisor\",name!=\"\"}", "legendFormat": "{{name}} Usage", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "container_memory_working_set_bytes{job=\"cadvisor\",name!=\"\"}", "legendFormat": "{{name}} Working Set", "refId": "B"}
       ],
       "title": "컨테이너 메모리 사용량",
       "type": "timeseries"
@@ -697,6 +697,64 @@
         {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{application=\"$application\", level=~\"$level\"}", "refId": "A"}
       ],
       "title": "실시간 애플리케이션 로그",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 118},
+      "id": 90,
+      "title": "크롤링 서비스 (Loki)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 12, "x": 0, "y": 119},
+      "id": 91,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "sum(count_over_time({service=\"ajouevent-crawling\"} |= \"crawl_tick\" [1h]))", "legendFormat": "실행 횟수 (1h)", "refId": "A"}
+      ],
+      "title": "크롤링 실행 횟수 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 12, "x": 12, "y": 119},
+      "id": 92,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "sum(count_over_time({service=\"ajouevent-crawling\"} |~ \"(?i)(error|panic|fatal)\" [1h]))", "legendFormat": "에러 수 (1h)", "refId": "A"}
+      ],
+      "title": "크롤링 에러 수 (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 14, "w": 24, "x": 0, "y": 123},
+      "id": 93,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
+      "targets": [
+        {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{service=\"ajouevent-crawling\"}", "refId": "A"}
+      ],
+      "title": "크롤링 실시간 로그",
       "type": "logs"
     }
   ],


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #109 

## 💡 작업 내용

> 크롤링 서비스를 Grafana 모니터링 환경에 통합하고, cAdvisor 컨테이너 메트릭이 표시되지 않던 문제를 수정합니다.

**변경 파일**
- `monitoring/grafana/dashboards/ajouevent.json`

**cAdvisor 쿼리 수정**
- 컨테이너 CPU/메모리 패널의 필터를 `id=~"/docker/.+"` → `name!=""`로 변경
- 범례를 `{{id}}` → `{{name}}`으로 변경하여 컨테이너 이름으로 식별

**크롤링 서비스 모니터링 섹션 추가**
대시보드 하단에 "크롤링 서비스 (Loki)" 섹션을 추가합니다.

| 패널 | 쿼리 | 설명 |
|------|------|------|
| 크롤링 실행 횟수 (1h) | `count_over_time({service="ajouevent-crawling"} \|= "crawl_tick" [1h])` | 크롤링 tick 발생 횟수 |
| 크롤링 에러 수 (1h) | `count_over_time({service="ajouevent-crawling"} \|~ "(?i)(error\|panic\|fatal)" [1h])` | 에러/패닉/치명 로그 건수 |
| 크롤링 실시간 로그 | `{service="ajouevent-crawling"}` | 전체 실시간 로그 스트림 |

## 📝 추가 설명(선택)

크롤링 서비스(`AjouEvent_Crawling_V2`)는 독립 compose와 CI/CD로 계속 별도 관리됩니다.
이미 Loki Docker 드라이버로 로그를 전송하고 있으므로(`loki-external-labels: service=ajouevent-crawling`) 인프라 변경 없이 대시보드 추가만으로 통합이 가능합니다.